### PR TITLE
Add Terraform IaC + GitHub Actions deploy workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,13 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - run: docker build .
+  terraform:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ~1.14
+      - run: terraform -chdir=Terraform fmt -check -diff
+      - run: terraform -chdir=Terraform init -backend=false
+      - run: terraform -chdir=Terraform validate

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,13 +28,16 @@ jobs:
       - id: auth
         uses: google-github-actions/auth@v2
         with:
+          project_id: ${{ env.PROJECT_ID }}
           workload_identity_provider: ${{ vars.GOOGLE_CLOUD_WIF_PROVIDER }}
           service_account: ${{ vars.GOOGLE_CLOUD_DEPLOYER_SA }}
 
       - uses: google-github-actions/setup-gcloud@v2
+        with:
+          project_id: ${{ env.PROJECT_ID }}
 
       - name: Configure Docker auth for Artifact Registry
-        run: gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev --quiet
+        run: gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev --project="$PROJECT_ID" --quiet
 
       - uses: docker/setup-buildx-action@v3
 
@@ -50,5 +53,6 @@ jobs:
       - name: Update Cloud Run service image
         run: |
           gcloud run services update "$SERVICE" \
+            --project="$PROJECT_ID" \
             --region="$REGION" \
             --image="${REGION}-docker.pkg.dev/${PROJECT_ID}/${REPO}/${SERVICE}:${{ github.sha }}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,54 @@
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+
+# Serialize prod deploys but never cancel an in-flight one — overwriting an
+# image mid-rollout produces unpredictable revisions.
+concurrency:
+  group: deploy-prod
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write   # Required for Workload Identity Federation
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      PROJECT_ID: ${{ vars.GOOGLE_CLOUD_PROJECT }}
+      REGION: ${{ vars.GOOGLE_CLOUD_REGION }}
+      SERVICE: ${{ vars.GOOGLE_CLOUD_SERVICE_NAME }}
+      REPO: ${{ vars.GOOGLE_CLOUD_ARTIFACT_REPO }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ vars.GOOGLE_CLOUD_WIF_PROVIDER }}
+          service_account: ${{ vars.GOOGLE_CLOUD_DEPLOYER_SA }}
+
+      - uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker auth for Artifact Registry
+        run: gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev --quiet
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPO }}/${{ env.SERVICE }}:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Update Cloud Run service image
+        run: |
+          gcloud run services update "$SERVICE" \
+            --region="$REGION" \
+            --image="${REGION}-docker.pkg.dev/${PROJECT_ID}/${REPO}/${SERVICE}:${{ github.sha }}"

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,9 @@ xcuserdata/
 .env.*
 .env
 DerivedData
+
+# Terraform
+**/.terraform/
+**/terraform.tfvars
+**/*.tfstate
+**/*.tfstate.*

--- a/Terraform/.terraform.lock.hcl
+++ b/Terraform/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "6.50.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:79CwMTsp3Ud1nOl5hFS5mxQHyT0fGVye7pqpU0PPlHI=",
+    "zh:1f3513fcfcbf7ca53d667a168c5067a4dd91a4d4cccd19743e248ff31065503c",
+    "zh:3da7db8fc2c51a77dd958ea8baaa05c29cd7f829bd8941c26e2ea9cb3aadc1e5",
+    "zh:3e09ac3f6ca8111cbb659d38c251771829f4347ab159a12db195e211c76068bb",
+    "zh:7bb9e41c568df15ccf1a8946037355eefb4dfb4e35e3b190808bb7c4abae547d",
+    "zh:81e5d78bdec7778e6d67b5c3544777505db40a826b6eb5abe9b86d4ba396866b",
+    "zh:8d309d020fb321525883f5c4ea864df3d5942b6087f6656d6d8b3a1377f340fc",
+    "zh:93e112559655ab95a523193158f4a4ac0f2bfed7eeaa712010b85ebb551d5071",
+    "zh:d3efe589ffd625b300cef5917c4629513f77e3a7b111c9df65075f76a46a63c7",
+    "zh:d4a4d672bbef756a870d8f32b35925f8ce2ef4f6bbd5b71a3cb764f1b6c85421",
+    "zh:e13a86bca299ba8a118e80d5f84fbdd708fe600ecdceea1a13d4919c068379fe",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fec30c095647b583a246c39d557704947195a1b7d41f81e369ba377d997faef6",
+  ]
+}

--- a/Terraform/README.md
+++ b/Terraform/README.md
@@ -10,6 +10,7 @@ Image のビルドと push、Cloud Run への反映は GitHub Actions が行う 
 - **認証**: Workload Identity Federation。長期鍵 (JSON) なし
 - **Terraform 実行**: 当面オペレータ手元から (GHA で terraform apply は回さない)
 - **環境**: prod のみ
+- **公開範囲**: `allow_unauthenticated = true` のため Cloud Run は **public endpoint** として公開される。アプリ層 (Hummingbird) の認証ミドルウェア + Valkey ベースのレートリミットで保護する前提。
 
 ## Bootstrap 手順 (初回のみ)
 
@@ -32,10 +33,11 @@ gcloud config set project "$PROJECT_ID"
 
 ### 2. 必要 API の先行有効化
 
-Terraform 自身が `google_project_service` で有効化するが、`cloudresourcemanager` と `iam` は API 未有効だと `terraform init` すら通らないので手で有効化しておく。
+Terraform 自身が `google_project_service` で残りを有効化するが、その前段で `serviceusage` (他 API を有効化するための API)、`cloudresourcemanager` (project lookup)、`iam` の 3 つは手で有効化しておく必要がある。これらが無効だと `terraform init` / 最初の `apply` が通らない。
 
 ```sh
 gcloud services enable \
+  serviceusage.googleapis.com \
   cloudresourcemanager.googleapis.com \
   iam.googleapis.com
 ```
@@ -69,6 +71,8 @@ terraform init \
 ### 6. 既存リソースを import
 
 現在 Google Cloud コンソールで動いている Cloud Run サービスを destroy/recreate すると本番が落ちる。以下を先に import する。
+
+> **ブラウンフィールド注意**: 過去に手動で作った同名リソース (例: `blindlog-api-runtime` SA、`github-pool` WIF pool、Artifact Registry repo) が残っている場合、初回 apply で `Already Exists` エラーになる。下記の Cloud Run / AR / Secret に加え、既存の SA や WIF pool/provider があれば同様に import する (resource address は `terraform plan` の create 計画から逆引き)。新規プロジェクトでの bootstrap なら不要。
 
 ```sh
 # 直前に手順 0 の env が export されていることを確認

--- a/Terraform/README.md
+++ b/Terraform/README.md
@@ -1,0 +1,175 @@
+# blindlog-api Terraform (prod)
+
+Cloud Run / Artifact Registry / Secret Manager / IAM を Terraform で管理する。
+Image のビルドと push、Cloud Run への反映は GitHub Actions が行う (`.github/workflows/deploy.yml`)。
+
+## 構成概要
+
+- **PR**: 既存の `ci.yml` が Docker build 検証のみ (push しない)
+- **`main` push**: `deploy.yml` が build → Artifact Registry に push → `gcloud run services update --image=...` で Cloud Run 更新
+- **認証**: Workload Identity Federation。長期鍵 (JSON) なし
+- **Terraform 実行**: 当面オペレータ手元から (GHA で terraform apply は回さない)
+- **環境**: prod のみ
+
+## Bootstrap 手順 (初回のみ)
+
+### 0. 作業用環境変数を設定
+
+以降のコマンドで使い回すのでシェルに export しておく。新しいターミナルで作業を再開する場合は毎回ここから実行する。
+
+```sh
+export PROJECT_ID="<your-gcp-project-id>"
+export REGION="asia-northeast1"              # prod Cloud Run を動かすリージョン
+export STATE_BUCKET="${PROJECT_ID}-tfstate"  # Terraform state 用 GCS バケット名
+```
+
+### 1. Google Cloud プロジェクトに Owner/Editor で認証
+
+```sh
+gcloud auth application-default login
+gcloud config set project "$PROJECT_ID"
+```
+
+### 2. 必要 API の先行有効化
+
+Terraform 自身が `google_project_service` で有効化するが、`cloudresourcemanager` と `iam` は API 未有効だと `terraform init` すら通らないので手で有効化しておく。
+
+```sh
+gcloud services enable \
+  cloudresourcemanager.googleapis.com \
+  iam.googleapis.com
+```
+
+### 3. State bucket 作成
+
+Terraform の state を保存する GCS バケット (名前は `$STATE_BUCKET`) を作る。バケット名は Google Cloud 全体でグローバル一意なので、`<PROJECT_ID>-tfstate` 形式にしておけば衝突しにくい。
+
+```sh
+gcloud storage buckets create "gs://$STATE_BUCKET" \
+  --location="$REGION" \
+  --uniform-bucket-level-access
+gcloud storage buckets update "gs://$STATE_BUCKET" --versioning
+```
+
+### 4. 変数ファイルを作る
+
+```sh
+cp terraform.tfvars.example terraform.tfvars
+$EDITOR terraform.tfvars
+```
+
+### 5. `terraform init`
+
+```sh
+terraform init \
+  -backend-config="bucket=$STATE_BUCKET" \
+  -backend-config="prefix=blindlog-api"
+```
+
+### 6. 既存リソースを import
+
+現在 Google Cloud コンソールで動いている Cloud Run サービスを destroy/recreate すると本番が落ちる。以下を先に import する。
+
+```sh
+# 直前に手順 0 の env が export されていることを確認
+echo "Importing into project=$PROJECT_ID, region=$REGION"
+test -n "$PROJECT_ID" -a -n "$REGION" || { echo "PROJECT_ID/REGION not set"; exit 1; }
+
+# 既存 Cloud Run service
+terraform import google_cloud_run_v2_service.api \
+  "projects/$PROJECT_ID/locations/$REGION/services/blindlog-api"
+
+# Artifact Registry repo (すでに作っている場合のみ)
+terraform import google_artifact_registry_repository.app \
+  "projects/$PROJECT_ID/locations/$REGION/repositories/blindlog-api"
+
+# 既存の Secret Manager secret (1個ずつ)
+terraform import 'google_secret_manager_secret.app["POSTGRES_PASSWORD"]' \
+  "projects/$PROJECT_ID/secrets/POSTGRES_PASSWORD"
+terraform import 'google_secret_manager_secret.app["VALKEY_PASSWORD"]' \
+  "projects/$PROJECT_ID/secrets/VALKEY_PASSWORD"
+terraform import 'google_secret_manager_secret.app["EDDSA_PRIVATE_KEY"]' \
+  "projects/$PROJECT_ID/secrets/EDDSA_PRIVATE_KEY"
+terraform import 'google_secret_manager_secret.app["CLOUDFLARE_API_TOKEN"]' \
+  "projects/$PROJECT_ID/secrets/CLOUDFLARE_API_TOKEN"
+terraform import 'google_secret_manager_secret.app["OTP_SECRET_KEY"]' \
+  "projects/$PROJECT_ID/secrets/OTP_SECRET_KEY"
+```
+
+(既存の secret_id が上と違う場合は Google Cloud コンソールで確認して合わせる。)
+
+### 7. Plan が空になるまで調整
+
+```sh
+terraform plan
+```
+
+差分が出るものを `terraform.tfvars` の `app_env` と各 `variables.tf` の値で一致させる。annotations やラベルなど無害な drift が残る場合は `cloud_run.tf` の `lifecycle.ignore_changes` に追加する。
+
+**重要**: `image_tag` は現在 prod で動いている image の tag を渡す (例: `image_tag = "<current-sha>"`)。ただし `ignore_changes = [template[0].containers[0].image]` を入れているため、ここで渡した値は実際には適用されず、現行の image タグはそのまま維持される。
+
+### 8. `terraform apply`
+
+```sh
+terraform apply
+```
+
+WIF pool/provider, deployer SA, IAM bindings などの新規リソースが作成される。
+
+### 9. Secret 値のアップロード
+
+Terraform は secret の「入れ物」だけ作る。値は手で入れる。
+
+```sh
+printf '%s' "<POSTGRES_PASSWORD_VALUE>"    | gcloud secrets versions add POSTGRES_PASSWORD    --data-file=-
+printf '%s' "<VALKEY_PASSWORD_VALUE>"      | gcloud secrets versions add VALKEY_PASSWORD      --data-file=-
+printf '%s' "<EDDSA_PRIVATE_KEY_VALUE>"    | gcloud secrets versions add EDDSA_PRIVATE_KEY    --data-file=-
+printf '%s' "<CLOUDFLARE_API_TOKEN_VALUE>" | gcloud secrets versions add CLOUDFLARE_API_TOKEN --data-file=-
+printf '%s' "<OTP_SECRET_KEY_VALUE>"       | gcloud secrets versions add OTP_SECRET_KEY       --data-file=-
+```
+
+### 10. GitHub 側の設定
+
+`terraform output` で値を確認し、GitHub リポジトリの Settings → Secrets and variables → Actions → **Variables** に登録する (Secrets ではなく Variables で良い。WIF 構成値は機密ではない)。
+
+| Variable 名 | 値のソース |
+|---|---|
+| `GOOGLE_CLOUD_PROJECT` | `terraform.tfvars` の `project_id` |
+| `GOOGLE_CLOUD_REGION` | `terraform.tfvars` の `region` |
+| `GOOGLE_CLOUD_SERVICE_NAME` | `terraform.tfvars` の `service_name` (未指定なら `blindlog-api`) |
+| `GOOGLE_CLOUD_ARTIFACT_REPO` | `terraform.tfvars` の `artifact_repo_id` (未指定なら `blindlog-api`) |
+| `GOOGLE_CLOUD_WIF_PROVIDER` | `terraform output -raw wif_provider` |
+| `GOOGLE_CLOUD_DEPLOYER_SA` | `terraform output -raw deployer_sa_email` |
+
+### 11. 既存の Cloud Build トリガーを無効化
+
+```sh
+gcloud builds triggers list
+gcloud builds triggers update <TRIGGER_ID> --disabled=true
+```
+
+GHA deploy がグリーンになってから 1〜2 週間問題なく回ったことを確認し、問題なければ `gcloud builds triggers delete <TRIGGER_ID>`。
+
+## 日常運用
+
+### 設定変更
+
+Cloud Run の env / scaling / resources などは `terraform.tfvars` や `*.tf` を編集して `terraform apply`。GHA の image 更新とは独立している (image は `ignore_changes`)。
+
+### Secret 値のローテーション
+
+```sh
+printf '%s' "<new>" | gcloud secrets versions add <secret-id> --data-file=-
+```
+
+Cloud Run は `version = "latest"` 参照なので、次回リビジョン作成時に新しい値が読まれる。すぐ反映させたい場合は GHA deploy を回すか、`gcloud run services update blindlog-api --region=$REGION --update-env-vars=_DUMMY=$(date +%s)` のような空更新で新リビジョンを作る。
+
+### Image ロールバック
+
+過去の SHA を指定して手で回す (Bootstrap 手順 0 と同じ `PROJECT_ID`/`REGION` を export しておく):
+
+```sh
+gcloud run services update blindlog-api \
+  --region="$REGION" \
+  --image="$REGION-docker.pkg.dev/$PROJECT_ID/blindlog-api/blindlog-api:<OLD_SHA>"
+```

--- a/Terraform/apis.tf
+++ b/Terraform/apis.tf
@@ -1,0 +1,16 @@
+resource "google_project_service" "required" {
+  for_each = toset([
+    "artifactregistry.googleapis.com",
+    "cloudresourcemanager.googleapis.com",
+    "iam.googleapis.com",
+    "iamcredentials.googleapis.com",
+    "logging.googleapis.com",
+    "monitoring.googleapis.com",
+    "run.googleapis.com",
+    "secretmanager.googleapis.com",
+    "sts.googleapis.com",
+  ])
+
+  service            = each.value
+  disable_on_destroy = false
+}

--- a/Terraform/apis.tf
+++ b/Terraform/apis.tf
@@ -8,6 +8,8 @@ resource "google_project_service" "required" {
     "monitoring.googleapis.com",
     "run.googleapis.com",
     "secretmanager.googleapis.com",
+    "serviceusage.googleapis.com",
+    "storage.googleapis.com",
     "sts.googleapis.com",
   ])
 

--- a/Terraform/artifact_registry.tf
+++ b/Terraform/artifact_registry.tf
@@ -1,0 +1,17 @@
+resource "google_artifact_registry_repository" "app" {
+  depends_on = [google_project_service.required]
+
+  repository_id = var.artifact_repo_id
+  location      = var.region
+  format        = "DOCKER"
+  description   = "Container images for ${var.service_name}."
+}
+
+# Scope artifactregistry.writer to the one repo rather than project-wide.
+resource "google_artifact_registry_repository_iam_member" "deployer_ar_writer" {
+  project    = var.project_id
+  location   = google_artifact_registry_repository.app.location
+  repository = google_artifact_registry_repository.app.name
+  role       = "roles/artifactregistry.writer"
+  member     = "serviceAccount:${google_service_account.deployer.email}"
+}

--- a/Terraform/cloud_run.tf
+++ b/Terraform/cloud_run.tf
@@ -1,0 +1,106 @@
+resource "google_cloud_run_v2_service" "api" {
+  depends_on = [
+    google_project_service.required,
+    google_secret_manager_secret_iam_member.runtime_access,
+  ]
+
+  name                = var.service_name
+  location            = var.region
+  ingress             = "INGRESS_TRAFFIC_ALL"
+  deletion_protection = true
+
+  template {
+    service_account = google_service_account.runtime.email
+
+    scaling {
+      min_instance_count = var.min_instance_count
+      max_instance_count = var.max_instance_count
+    }
+
+    containers {
+      name  = "app"
+      image = local.image_url
+
+      ports {
+        container_port = 8080
+      }
+
+      resources {
+        limits = {
+          cpu    = var.cpu
+          memory = var.memory
+        }
+        cpu_idle          = true
+        startup_cpu_boost = true
+      }
+
+      # Non-sensitive env vars (CLOUD_RUN_REGION is auto-injected from var.region).
+      dynamic "env" {
+        for_each = local.plain_env
+        content {
+          name  = env.key
+          value = env.value
+        }
+      }
+
+      # Sensitive env vars sourced from Secret Manager.
+      dynamic "env" {
+        for_each = local.secret_env_names
+        content {
+          name = env.value
+          value_source {
+            secret_key_ref {
+              secret  = google_secret_manager_secret.app[env.value].secret_id
+              version = "latest"
+            }
+          }
+        }
+      }
+
+      # Match existing prod probe (long timeout, single attempt). Tuned so a
+      # cold start that triggers DB migrations doesn't get killed prematurely.
+      startup_probe {
+        tcp_socket {
+          port = 8080
+        }
+        timeout_seconds   = 240
+        period_seconds    = 240
+        failure_threshold = 1
+      }
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      # GitHub Actions updates the running image via `gcloud run services update`.
+      # Keeping this ignored prevents `terraform apply` from reverting prod.
+      template[0].containers[0].image,
+      # Cloud Build / gcloud deploy auto-stamps these on each revision.
+      template[0].labels,
+      template[0].annotations,
+      client,
+      client_version,
+    ]
+  }
+}
+
+# Scope deployer's Cloud Run permissions to the one service rather than project-wide.
+# `roles/run.developer` includes `run.services.update` which is what the GHA
+# workflow calls via `gcloud run services update --image=...`.
+resource "google_cloud_run_v2_service_iam_member" "deployer_developer" {
+  project  = google_cloud_run_v2_service.api.project
+  location = google_cloud_run_v2_service.api.location
+  name     = google_cloud_run_v2_service.api.name
+  role     = "roles/run.developer"
+  member   = "serviceAccount:${google_service_account.deployer.email}"
+}
+
+resource "google_cloud_run_v2_service_iam_member" "invoker" {
+  count = var.allow_unauthenticated ? 1 : 0
+
+  project  = google_cloud_run_v2_service.api.project
+  location = google_cloud_run_v2_service.api.location
+  name     = google_cloud_run_v2_service.api.name
+  role     = "roles/run.invoker"
+  member   = "allUsers"
+}

--- a/Terraform/locals.tf
+++ b/Terraform/locals.tf
@@ -1,0 +1,20 @@
+locals {
+  image_url = "${var.region}-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.app.repository_id}/${var.service_name}:${var.image_tag}"
+
+  # Final env-var map injected into the container.
+  # CLOUD_RUN_REGION is derived from var.region so it can't drift from where
+  # the service actually runs.
+  plain_env = merge(var.app_env, {
+    CLOUD_RUN_REGION = var.region
+  })
+
+  # Sensitive env vars sourced from Secret Manager. The env var name and the
+  # Secret Manager secret_id are identical, so a single set is sufficient.
+  secret_env_names = toset([
+    "CLOUDFLARE_API_TOKEN",
+    "EDDSA_PRIVATE_KEY",
+    "OTP_SECRET_KEY",
+    "POSTGRES_PASSWORD",
+    "VALKEY_PASSWORD",
+  ])
+}

--- a/Terraform/outputs.tf
+++ b/Terraform/outputs.tf
@@ -1,0 +1,39 @@
+output "artifact_repo" {
+  description = "Artifact Registry path (host/project/repo). Prefix for pushed image tags."
+  value       = "${google_artifact_registry_repository.app.location}-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.app.repository_id}"
+}
+
+output "deployer_sa_email" {
+  description = "Service account email impersonated by GitHub Actions. Pass to google-github-actions/auth as `service_account`."
+  value       = google_service_account.deployer.email
+}
+
+output "project_id" {
+  description = "Google Cloud project ID. Echoed for use in CI variable wiring."
+  value       = var.project_id
+}
+
+output "region" {
+  description = "Region the service runs in. Echoed for use in CI variable wiring."
+  value       = var.region
+}
+
+output "runtime_sa_email" {
+  description = "Service account used by Cloud Run at runtime."
+  value       = google_service_account.runtime.email
+}
+
+output "secrets" {
+  description = "Map of Secret Manager secrets created for the app. Use `gcloud secrets versions add <id> --data-file=-` to upload values."
+  value       = { for k, v in google_secret_manager_secret.app : k => v.id }
+}
+
+output "service_url" {
+  description = "Public URL of the Cloud Run service."
+  value       = google_cloud_run_v2_service.api.uri
+}
+
+output "wif_provider" {
+  description = "Full resource name of the WIF provider. Pass to google-github-actions/auth as `workload_identity_provider`."
+  value       = google_iam_workload_identity_pool_provider.github.name
+}

--- a/Terraform/providers.tf
+++ b/Terraform/providers.tf
@@ -1,0 +1,9 @@
+provider "google" {
+  project = var.project_id
+  region  = var.region
+
+  default_labels = {
+    managed_by = "terraform"
+    service    = "blindlog-api"
+  }
+}

--- a/Terraform/secrets.tf
+++ b/Terraform/secrets.tf
@@ -1,0 +1,22 @@
+resource "google_secret_manager_secret" "app" {
+  for_each   = local.secret_env_names
+  depends_on = [google_project_service.required]
+
+  secret_id = each.value
+
+  replication {
+    auto {}
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "google_secret_manager_secret_iam_member" "runtime_access" {
+  for_each = local.secret_env_names
+
+  secret_id = google_secret_manager_secret.app[each.value].id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.runtime.email}"
+}

--- a/Terraform/service_accounts.tf
+++ b/Terraform/service_accounts.tf
@@ -1,0 +1,34 @@
+resource "google_service_account" "runtime" {
+  depends_on = [google_project_service.required]
+
+  account_id   = "${var.service_name}-runtime"
+  display_name = "${var.service_name} Cloud Run runtime"
+  description  = "Identity for the Cloud Run service at runtime."
+}
+
+resource "google_project_iam_member" "runtime_log_writer" {
+  project = var.project_id
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.runtime.email}"
+}
+
+resource "google_project_iam_member" "runtime_metric_writer" {
+  project = var.project_id
+  role    = "roles/monitoring.metricWriter"
+  member  = "serviceAccount:${google_service_account.runtime.email}"
+}
+
+resource "google_service_account" "deployer" {
+  depends_on = [google_project_service.required]
+
+  account_id   = "${var.service_name}-deployer"
+  display_name = "${var.service_name} GitHub Actions deployer"
+  description  = "Impersonated by GitHub Actions (via WIF) to push images and update Cloud Run."
+}
+
+# Required so deployer can deploy a Cloud Run service that runs-as the runtime SA.
+resource "google_service_account_iam_member" "deployer_actas_runtime" {
+  service_account_id = google_service_account.runtime.name
+  role               = "roles/iam.serviceAccountUser"
+  member             = "serviceAccount:${google_service_account.deployer.email}"
+}

--- a/Terraform/terraform.tf
+++ b/Terraform/terraform.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_version = ">= 1.14"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+  }
+
+  backend "gcs" {
+    # bucket and prefix are supplied via `terraform init -backend-config=...`.
+    # See Terraform/README.md §5 for the exact init command.
+  }
+}

--- a/Terraform/terraform.tfvars.example
+++ b/Terraform/terraform.tfvars.example
@@ -1,0 +1,43 @@
+project_id     = "your-gcp-project-id"
+project_number = "123456789012"
+region         = "asia-northeast1"
+
+# Optional overrides (defaults are fine for a single-service prod setup)
+# service_name       = "blindlog-api"
+# artifact_repo_id   = "blindlog-api"
+# github_repo        = "BlindLog/blindlog-api"
+# min_instance_count = 0
+# max_instance_count = 10
+# cpu                = "1"
+# memory             = "512Mi"
+# allow_unauthenticated = true
+
+# First `terraform apply` uses this tag. After that, GitHub Actions overrides
+# the running image with `gcloud run services update --image=...:<sha>`, and
+# Terraform ignores image drift (see cloud_run.tf lifecycle block).
+image_tag = "bootstrap"
+
+# Non-sensitive environment variables.
+# Sensitive values (POSTGRES_PASSWORD, VALKEY_PASSWORD, EDDSA_PRIVATE_KEY,
+# CLOUDFLARE_API_TOKEN, OTP_SECRET_KEY) are managed via Secret Manager —
+# upload versions with `gcloud secrets versions add <id> --data-file=-`.
+#
+# CLOUD_RUN_REGION is auto-injected from `region` above; do NOT set it here.
+# RELYING_PARTY_ORIGIN should be the public-facing origin (custom domain or
+# Cloud Run URL), NOT a placeholder.
+app_env = {
+  APPLE_APP_ID                   = "XXXXXXXX.com.example.app"
+  RELYING_PARTY_ID               = "example.com"
+  RELYING_PARTY_NAME             = "Example"
+  RELYING_PARTY_ORIGIN           = "https://example.com" # REQUIRED: replace with the public-facing origin (custom domain or Cloud Run URL); WebAuthn fails if this is wrong.
+  POSTGRES_HOSTNAME              = "db.example.com"
+  POSTGRES_USER                  = "blindlog"
+  POSTGRES_DB                    = "blindlog"
+  VALKEY_HOSTNAME                = "cache.example.com"
+  VALKEY_USERNAME                = "default"
+  CLOUDFLARE_ACCOUNT_ID          = "xxxxxxxxxxxxxxxx"
+  LOG_LEVEL                      = "info"
+  RATELIMIT_DURATION_SECONDS     = "60"
+  RATELIMIT_IP_ADDRESS_MAX_COUNT = "60"
+  RATELIMIT_USER_TOKEN_MAX_COUNT = "120"
+}

--- a/Terraform/terraform.tfvars.example
+++ b/Terraform/terraform.tfvars.example
@@ -5,7 +5,7 @@ region         = "asia-northeast1"
 # Optional overrides (defaults are fine for a single-service prod setup)
 # service_name       = "blindlog-api"
 # artifact_repo_id   = "blindlog-api"
-# github_repo        = "BlindLog/blindlog-api"
+# github_repo        = "zunda-pixel/blindlog-api"
 # min_instance_count = 0
 # max_instance_count = 10
 # cpu                = "1"

--- a/Terraform/variables.tf
+++ b/Terraform/variables.tf
@@ -35,11 +35,11 @@ variable "deploy_branch" {
 variable "github_repo" {
   description = "GitHub repo allowed to assume the deployer service account, in `owner/name` form."
   type        = string
-  default     = "BlindLog/blindlog-api"
+  default     = "zunda-pixel/blindlog-api"
 
   validation {
     condition     = can(regex("^[^/]+/[^/]+$", var.github_repo))
-    error_message = "github_repo must be in `owner/name` form, e.g. \"BlindLog/blindlog-api\"."
+    error_message = "github_repo must be in `owner/name` form, e.g. \"zunda-pixel/blindlog-api\"."
   }
 }
 

--- a/Terraform/variables.tf
+++ b/Terraform/variables.tf
@@ -1,0 +1,105 @@
+variable "allow_unauthenticated" {
+  description = "Whether to allow public (unauthenticated) invocations of the Cloud Run service."
+  type        = bool
+  default     = true
+}
+
+variable "app_env" {
+  description = "Non-sensitive environment variables passed to the app container."
+  type        = map(string)
+}
+
+variable "artifact_repo_id" {
+  description = "Artifact Registry repository ID."
+  type        = string
+  default     = "blindlog-api"
+}
+
+variable "cpu" {
+  description = "Cloud Run container CPU limit (vCPU count or millicpu, e.g. \"1\", \"2\", \"500m\")."
+  type        = string
+  default     = "1"
+}
+
+variable "deploy_branch" {
+  description = "Git ref allowed to mint deployer tokens via Workload Identity Federation."
+  type        = string
+  default     = "refs/heads/main"
+
+  validation {
+    condition     = startswith(var.deploy_branch, "refs/")
+    error_message = "deploy_branch must be a fully-qualified ref, e.g. \"refs/heads/main\"."
+  }
+}
+
+variable "github_repo" {
+  description = "GitHub repo allowed to assume the deployer service account, in `owner/name` form."
+  type        = string
+  default     = "BlindLog/blindlog-api"
+
+  validation {
+    condition     = can(regex("^[^/]+/[^/]+$", var.github_repo))
+    error_message = "github_repo must be in `owner/name` form, e.g. \"BlindLog/blindlog-api\"."
+  }
+}
+
+variable "image_tag" {
+  description = "Initial image tag used on `terraform apply`. After first apply, GitHub Actions updates the running tag; Terraform ignores image drift."
+  type        = string
+  default     = "bootstrap"
+}
+
+variable "max_instance_count" {
+  description = "Maximum number of Cloud Run container instances."
+  type        = number
+  default     = 10
+
+  validation {
+    condition     = var.max_instance_count >= 1
+    error_message = "max_instance_count must be at least 1."
+  }
+}
+
+variable "memory" {
+  description = "Cloud Run container memory limit (e.g. \"512Mi\", \"1Gi\")."
+  type        = string
+  default     = "512Mi"
+}
+
+variable "min_instance_count" {
+  description = "Minimum number of Cloud Run container instances kept warm."
+  type        = number
+  default     = 0
+
+  validation {
+    condition     = var.min_instance_count >= 0
+    error_message = "min_instance_count must be non-negative."
+  }
+}
+
+variable "project_id" {
+  description = "Google Cloud project ID."
+  type        = string
+}
+
+variable "project_number" {
+  description = "Google Cloud project number. Used in the Workload Identity Federation principalSet."
+  type        = string
+}
+
+variable "region" {
+  description = "Google Cloud region for Cloud Run and Artifact Registry."
+  type        = string
+  default     = "asia-northeast1"
+
+  validation {
+    condition     = can(regex("^[a-z]+-[a-z]+[0-9]+$", var.region))
+    error_message = "region must look like a valid GCP region, e.g. \"asia-northeast1\"."
+  }
+}
+
+variable "service_name" {
+  description = "Cloud Run service name."
+  type        = string
+  default     = "blindlog-api"
+}

--- a/Terraform/wif.tf
+++ b/Terraform/wif.tf
@@ -1,0 +1,33 @@
+resource "google_iam_workload_identity_pool" "github" {
+  depends_on = [google_project_service.required]
+
+  workload_identity_pool_id = "github-pool"
+  display_name              = "GitHub Actions"
+  description               = "OIDC pool for GitHub Actions workflows."
+}
+
+resource "google_iam_workload_identity_pool_provider" "github" {
+  workload_identity_pool_id          = google_iam_workload_identity_pool.github.workload_identity_pool_id
+  workload_identity_pool_provider_id = "github"
+  display_name                       = "GitHub OIDC"
+
+  attribute_mapping = {
+    "google.subject"       = "assertion.sub"
+    "attribute.repository" = "assertion.repository"
+    "attribute.ref"        = "assertion.ref"
+  }
+
+  # Hard-restrict token exchange to a single branch of this repo only.
+  attribute_condition = "assertion.repository == \"${var.github_repo}\" && assertion.ref == \"${var.deploy_branch}\""
+
+  oidc {
+    issuer_uri = "https://token.actions.githubusercontent.com"
+  }
+}
+
+# Allow any workflow running in var.github_repo to impersonate the deployer SA.
+resource "google_service_account_iam_member" "deployer_wif" {
+  service_account_id = google_service_account.deployer.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "principalSet://iam.googleapis.com/projects/${var.project_number}/locations/global/workloadIdentityPools/${google_iam_workload_identity_pool.github.workload_identity_pool_id}/attribute.repository/${var.github_repo}"
+}


### PR DESCRIPTION
## Summary

Cloud Run 本番デプロイを **Google Cloud コンソールでの手動設定 → Terraform IaC + GitHub Actions** に移行する。

- Cloud Run / Artifact Registry / Secret Manager / IAM / Workload Identity Federation を `Terraform/` 配下で管理
- `main` push で GitHub Actions が image build → Artifact Registry に push → `gcloud run services update --image=...` で Cloud Run revision 更新
- 既存 `ci.yml` (lint / test / docker-build) は維持し、新たに `terraform` (fmt / init / validate) ジョブを追加
- Workload Identity Federation で長期 SA key 不要、`main` ブランチからのみ deploy 可能 (repo + ref で二重制限)

## Architecture

```
PR (any branch)        : ci.yml          → lint / test / docker-build / terraform validate
main push              : deploy.yml      → AR push → Cloud Run image update
terraform apply (手動) : Terraform/*.tf  → Cloud Run config / IAM / WIF / Secret Manager
```

- Image tag は GHA が更新するため、Terraform は `lifecycle.ignore_changes = [template[0].containers[0].image]` で drift を許容 (CI と TF の責務分離)
- Secret 値は state 外管理 (`gcloud secrets versions add` で別アップロード、`prevent_destroy = true`)
- 既存 prod リソース (Cloud Run / Artifact Registry / 5 Secrets) は `terraform import` で取り込み済、destroy なしで移行

## Security

- Workload Identity Federation で長期 SA key 廃止
- Deployer SA は最小権限: `roles/run.developer` (サービス単位) + `roles/artifactregistry.writer` (repo 単位) + `roles/iam.serviceAccountUser` (runtime SA 単位) + WIF impersonation
- Runtime SA は最小権限: `roles/logging.logWriter` + `roles/monitoring.metricWriter` + `roles/secretmanager.secretAccessor` (各 secret 単位)
- WIF condition: `assertion.repository == var.github_repo && assertion.ref == var.deploy_branch` (default は `zunda-pixel/blindlog-api` + `refs/heads/main`、`terraform.tfvars` で上書き可)
- `deletion_protection = true` で Cloud Run / secret 誤削除防止
- **公開範囲**: `allow_unauthenticated = true` で Cloud Run は public endpoint。アプリ層 (Hummingbird) の認証ミドルウェア + Valkey ベースのレートリミットで保護する前提

## Pre-merge checklist

- [x] `terraform fmt -check` clean
- [x] `terraform validate` Success
- [x] `terraform plan` 空 (drift なし)
- [x] 既存リソースを `terraform import` 済
- [x] `terraform apply` 完了、prod 動作中
- [x] GitHub Variables 6 件登録 (`GOOGLE_CLOUD_*`)
- [x] Secret Manager に 5 件の値登録済
- [x] `terraform.tfvars` の `RELYING_PARTY_ORIGIN` を実値に設定済

## Test plan

- [x] PR 作成時の `ci.yml` がグリーン (lint / test / docker-build / **terraform** 新ジョブ)
- [ ] main マージで `deploy.yml` が起動、Artifact Registry に新 image push される
- [ ] Cloud Run revision が新 image に切り替わる (`gcloud run services describe blindlog-api --region=$REGION --format='value(spec.template.spec.containers[0].image)'` で確認)
- [ ] サービス URL がヘルシー応答 (200)
- [ ] パスキー登録 / 認証の e2e 動作確認 (`RELYING_PARTY_ORIGIN` が正しい証明)
- [ ] deploy 後に `terraform plan` が空のまま (image drift が `ignore_changes` で無視されている)

## Post-merge actions

- [ ] 既存の Cloud Build トリガーを `gcloud builds triggers update <ID> --disabled` で停止
- [ ] 1〜2 週間問題なく回ったらトリガー削除 + Cloud Build 既定 SA に付いていた余計な `roles/run.admin` 等を剥がす

## Out-of-band

- 過去にローカル作業ツリーへ Cloudflare API トークンの実値が書き込まれた経緯あり (現在は HEAD と一致) → ダッシュボードで Revoke + 新規発行し、Secret Manager の `CLOUDFLARE_API_TOKEN` を更新する

## File layout

```
Terraform/
├── terraform.tf            Terraform / provider version + GCS backend
├── providers.tf            google provider (default_labels)
├── variables.tf            入力変数 (alphabetical)
├── outputs.tf              CI 連携用出力 (alphabetical)
├── locals.tf               image_url, plain_env, secret_env_names
├── apis.tf                 必須 GCP API 一覧
├── artifact_registry.tf    Docker repo + deployer の AR writer
├── service_accounts.tf     runtime / deployer SA + 関連 IAM
├── cloud_run.tf            Cloud Run v2 service + service-scoped run.developer + invoker
├── secrets.tf              5 secrets + runtime の secretAccessor
├── wif.tf                  WIF pool / provider + deployer impersonation
├── README.md               Bootstrap / import / 運用手順
├── terraform.tfvars.example
└── .terraform.lock.hcl

.github/workflows/
├── ci.yml                  PR trigger: lint / test / docker-build / terraform (new)
└── deploy.yml              main push trigger: build → AR push → Cloud Run update
```

## Notes

- Terraform 実行は当面オペレータ手元から (GHA で apply は回さない、prod 単一なので頻度低く十分)
- ディレクトリ命名は Swift Package 慣習 (`Sources/`, `Tests/`) に合わせて PascalCase `Terraform/`
- `Tests/Develop.xctestplan` は本 PR の対象外 (Swift 側ローカル開発用、別 PR で扱う)
