### PR TITLE
Setup Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,13 @@ updates:
     cooldown:
       default-days: 7
 
+  - package-ecosystem: "docker-compose"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+
   - package-ecosystem: "terraform"
     directory: "/Terraform"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,24 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     cooldown:
-        default-days: 7
+      default-days: 7
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: "terraform"
+    directory: "/Terraform"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     container: swift:latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
       - run: swift format lint -r -p -s .
   test:
     runs-on: ubuntu-latest
@@ -28,7 +28,7 @@ jobs:
       OTP_SECRET_KEY: 14nGf8gj0cPsgfZaoKKGBlmKz7kpcfgvYIGt0WH8BvE=
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
       - name: Start DB & Cache (wait for health)
         run: docker compose up -d --wait postgres valkey
       - name: Run tests (Swift in Docker)
@@ -38,13 +38,13 @@ jobs:
   docker-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
       - run: docker build .
   terraform:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: hashicorp/setup-terraform@v3
+      - uses: actions/checkout@v6.0.2
+      - uses: hashicorp/setup-terraform@v3.1.2
         with:
           terraform_version: ~1.14
       - run: terraform -chdir=Terraform fmt -check -diff

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,26 +23,26 @@ jobs:
       SERVICE: ${{ vars.GOOGLE_CLOUD_SERVICE_NAME }}
       REPO: ${{ vars.GOOGLE_CLOUD_ARTIFACT_REPO }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
 
       - id: auth
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v2.1.13
         with:
           project_id: ${{ env.PROJECT_ID }}
           workload_identity_provider: ${{ vars.GOOGLE_CLOUD_WIF_PROVIDER }}
           service_account: ${{ vars.GOOGLE_CLOUD_DEPLOYER_SA }}
 
-      - uses: google-github-actions/setup-gcloud@v2
+      - uses: google-github-actions/setup-gcloud@v2.2.1
         with:
           project_id: ${{ env.PROJECT_ID }}
 
       - name: Configure Docker auth for Artifact Registry
         run: gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev --project="$PROJECT_ID" --quiet
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v3.12.0
 
       - name: Build and push image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v6.19.2
         with:
           context: .
           push: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
   release:
     runs-on: ubuntu-slim
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
       - run: gh release create ${{ github.ref_name }} --generate-notes
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Terraform/terraform.tf
+++ b/Terraform/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.14"
+  required_version = "~> 1.14"
 
   required_providers {
     google = {


### PR DESCRIPTION
## Summary
- Dependabot の監視対象に Dockerfile、Docker Compose、Terraform を追加しました。
- GitHub Actions の `uses:` をメジャーバージョン固定から patch まで含む明示的なタグに更新しました。
- Node.js 20 deprecation 警告を避けるため、GitHub Actions を Node 24 対応版へ更新しました。
- Terraform CLI の `required_version` を `~> 1.14` にして、1.14 以上かつ 2.0 未満の範囲に制限しました。
- Dependabot が Actions / Docker / Docker Compose / Terraform の更新差分を検出しやすいように設定を整えました。

## Test plan
- `dependabot.yml` の構文と対象ディレクトリを確認しました。
- GitHub Actions の `uses:` に `@v6` などのメジャーのみ指定が残っていないことを確認しました。
- Workflow 内の JavaScript Actions が `runs.using: node24` を使っていることを確認しました。
- `Terraform/terraform.tf` の linter エラーがないことを確認しました。
- 設定ファイルのみの変更のため、アプリケーションテストは未実行です。