### PR TITLE
update Swift 6.3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
-    container: swift:latest
+    container: swift:6.3.1-noble
     steps:
       - uses: actions/checkout@v6
       - run: swift format lint -r -p -s .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # ================================
 # Build image
 # ================================
-FROM swift:6.2.1-noble AS build
+FROM swift:6.3.1-noble AS build
 
 # Install OS updates
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true \

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.2
+// swift-tools-version: 6.3
 
 import PackageDescription
 

--- a/compose.yml
+++ b/compose.yml
@@ -14,7 +14,7 @@ services:
       - ./Database/init:/docker-entrypoint-initdb.d
 
   swift:
-    image: swift:latest
+    image: swift:6.3.1-noble
     depends_on:
       - postgres
       - valkey


### PR DESCRIPTION
## Summary

* Swift toolchain を 6.3.1 系に更新しました。
* Dockerfile の build image を `swift:6.3.1-noble` に更新しました。
* CI と Docker Compose で使用する Swift image を `swift:6.3.1-noble` に固定しました。
* `Package.swift` の Swift tools version を 6.3 に更新しました。

## Test plan

* Swift のバージョン指定が 6.3 系に揃っていることを差分で確認しました。
* GitHub Actions の CI で lint / test / docker build が通ることを確認します。