### PR TITLE
Remove OTel collector self-referencing internal telemetry

### DIFF
--- a/Deploy/cloud-run/collector-config.yaml
+++ b/Deploy/cloud-run/collector-config.yaml
@@ -64,12 +64,3 @@ service:
       receivers: [otlp]
       processors: [resourcedetection, memory_limiter, batch]
       exporters: [googlecloud]
-  telemetry:
-    metrics:
-      readers:
-        - periodic:
-            exporter:
-              otlp:
-                protocol: grpc
-                endpoint: http://localhost:4317
-                insecure: true


### PR DESCRIPTION
## Summary

Drops the `service.telemetry.metrics` block from `Deploy/cloud-run/collector-config.yaml`. That block configured the collector to push its own metrics back to its own OTLP receiver at `localhost:4317`, which is a no-op self-loop in the sidecar topology and produces graceful-shutdown noise.

## Why

Observed in production after #123 deploy: every Cloud Run scale-down emits ~5 `grpc: addrConn.createTransport failed to connect to ... 127.0.0.1:4317: connect: connection refused` warnings over ~10 seconds. The OTLP receiver stops before the periodic metrics reader during shutdown, so the reader keeps trying to send to a now-closed local endpoint.

Even at runtime the loop has no value — the collector's self-metrics never leave the collector, since the OTLP receiver they hit is the same one feeding the configured pipelines (logs/metrics/traces) that already export to Cloud Logging / GMP / Cloud Trace. Removing the block loses nothing observable.

## Test plan

- [ ] Apply Terraform; new Secret Manager version is created from this file
- [ ] Roll a new revision (or wait for one) and verify `Cloud Run > Logs` for the collector container no longer shows `connection refused` warnings around shutdown
- [ ] Confirm application logs/metrics/traces still arrive in Cloud Logging / Cloud Trace / Cloud Monitoring (i.e. the user-facing pipelines were not affected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)