### PR TITLE
Fan out OTel telemetry to Grafana Cloud

### DIFF
--- a/Deploy/cloud-run/collector-config.yaml
+++ b/Deploy/cloud-run/collector-config.yaml
@@ -43,6 +43,10 @@ exporters:
     log:
       default_log_name: blindlog-api
   googlemanagedprometheus:
+  otlphttp/grafana:
+    endpoint: ${env:GRAFANA_OTLP_ENDPOINT}
+    headers:
+      authorization: "Basic ${env:GRAFANA_OTLP_AUTH}"
 
 extensions:
   health_check:
@@ -55,12 +59,12 @@ service:
     logs:
       receivers: [otlp]
       processors: [resourcedetection, memory_limiter, batch]
-      exporters: [googlecloud]
+      exporters: [googlecloud, otlphttp/grafana]
     metrics/otlp:
       receivers: [otlp]
       processors: [resourcedetection, transform/collision, memory_limiter, batch]
-      exporters: [googlemanagedprometheus]
+      exporters: [googlemanagedprometheus, otlphttp/grafana]
     traces:
       receivers: [otlp]
       processors: [resourcedetection, memory_limiter, batch]
-      exporters: [googlecloud]
+      exporters: [googlecloud, otlphttp/grafana]

--- a/Terraform/README.md
+++ b/Terraform/README.md
@@ -103,6 +103,10 @@ terraform import 'google_secret_manager_secret.app["OTP_SECRET_KEY"]' \
 # OTel Collector config secret (手動作成済みの場合のみ)
 terraform import google_secret_manager_secret.otel_collector_config \
   "projects/$PROJECT_ID/secrets/blindlog-otel-collector-config"
+
+# Grafana Cloud OTLP auth secret (手動作成済みの場合のみ)
+terraform import google_secret_manager_secret.grafana_otlp_auth \
+  "projects/$PROJECT_ID/secrets/GRAFANA_OTLP_AUTH"
 ```
 
 (既存の secret_id が上と違う場合は Google Cloud コンソールで確認して合わせる。)
@@ -140,6 +144,10 @@ printf '%s' "<VALKEY_PASSWORD_VALUE>"      | gcloud secrets versions add VALKEY_
 printf '%s' "<EDDSA_PRIVATE_KEY_VALUE>"    | gcloud secrets versions add EDDSA_PRIVATE_KEY    --data-file=-
 printf '%s' "<CLOUDFLARE_API_TOKEN_VALUE>" | gcloud secrets versions add CLOUDFLARE_API_TOKEN --data-file=-
 printf '%s' "<OTP_SECRET_KEY_VALUE>"       | gcloud secrets versions add OTP_SECRET_KEY       --data-file=-
+
+# Grafana Cloud OTLP Basic-auth header (only if grafana_otlp_endpoint is set)
+printf '%s' "$INSTANCE_ID:$API_TOKEN" | base64 | \
+  gcloud secrets versions add GRAFANA_OTLP_AUTH --data-file=-
 ```
 
 ### 10. 全体を `terraform apply`

--- a/Terraform/cloud_run.tf
+++ b/Terraform/cloud_run.tf
@@ -1,6 +1,7 @@
 resource "google_cloud_run_v2_service" "api" {
   depends_on = [
     google_project_service.required,
+    google_secret_manager_secret_iam_member.grafana_otlp_auth_runtime_access,
     google_secret_manager_secret_iam_member.otel_collector_config_runtime_access,
     google_secret_manager_secret_version.otel_collector_config,
     google_secret_manager_secret_iam_member.runtime_access,
@@ -85,6 +86,24 @@ resource "google_cloud_run_v2_service" "api" {
         }
         cpu_idle          = var.cpu_idle
         startup_cpu_boost = true
+      }
+
+      # Grafana Cloud OTLP fan-out. The collector references both env vars
+      # via ${env:VAR} substitution in collector-config.yaml. Endpoint is
+      # plaintext; the auth header (Basic base64(instanceID:apiToken)) is a
+      # secret. Setting var.grafana_otlp_endpoint to "" disables the export.
+      env {
+        name  = "GRAFANA_OTLP_ENDPOINT"
+        value = var.grafana_otlp_endpoint
+      }
+      env {
+        name = "GRAFANA_OTLP_AUTH"
+        value_source {
+          secret_key_ref {
+            secret  = google_secret_manager_secret.grafana_otlp_auth.secret_id
+            version = "latest"
+          }
+        }
       }
 
       startup_probe {

--- a/Terraform/secrets.tf
+++ b/Terraform/secrets.tf
@@ -45,3 +45,26 @@ resource "google_secret_manager_secret_iam_member" "otel_collector_config_runtim
   role      = "roles/secretmanager.secretAccessor"
   member    = "serviceAccount:${google_service_account.runtime.email}"
 }
+
+# Grafana Cloud OTLP Basic-auth header value, base64(instanceID:apiToken).
+# Versions are uploaded out-of-band (`gcloud secrets versions add ...`); Terraform
+# only manages the secret container and IAM binding.
+resource "google_secret_manager_secret" "grafana_otlp_auth" {
+  depends_on = [google_project_service.required]
+
+  secret_id = var.grafana_otlp_auth_secret_id
+
+  replication {
+    auto {}
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "google_secret_manager_secret_iam_member" "grafana_otlp_auth_runtime_access" {
+  secret_id = google_secret_manager_secret.grafana_otlp_auth.id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.runtime.email}"
+}

--- a/Terraform/terraform.tfvars.example
+++ b/Terraform/terraform.tfvars.example
@@ -17,6 +17,13 @@ region         = "asia-northeast1"
 # otel_collector_memory           = "256Mi"
 # allow_unauthenticated = true
 
+# Grafana Cloud OTLP fan-out. Leave empty to disable.
+# Endpoint: get from Grafana Cloud Portal -> Stack -> Connections -> OpenTelemetry (OTLP) -> Configure.
+# Auth: upload `printf '%s' "$INSTANCE_ID:$API_TOKEN" | base64` as a Secret Manager
+# version of the secret named by grafana_otlp_auth_secret_id (default: GRAFANA_OTLP_AUTH).
+# grafana_otlp_endpoint        = "https://otlp-gateway-prod-ap-northeast-0.grafana.net/otlp"
+# grafana_otlp_auth_secret_id  = "GRAFANA_OTLP_AUTH"
+
 # First `terraform apply` uses this tag. After that, GitHub Actions overrides
 # the running image with `gcloud run services update --image=...:<sha>`, and
 # Terraform ignores image drift (see cloud_run.tf lifecycle block).

--- a/Terraform/variables.tf
+++ b/Terraform/variables.tf
@@ -49,6 +49,18 @@ variable "github_repo" {
   }
 }
 
+variable "grafana_otlp_auth_secret_id" {
+  description = "Secret Manager secret ID storing the Basic-auth header value (base64(instanceID:apiToken)) for Grafana Cloud OTLP."
+  type        = string
+  default     = "GRAFANA_OTLP_AUTH"
+}
+
+variable "grafana_otlp_endpoint" {
+  description = "Grafana Cloud OTLP HTTP endpoint, e.g. \"https://otlp-gateway-prod-ap-northeast-0.grafana.net/otlp\". Set to an empty string to disable the Grafana exporter."
+  type        = string
+  default     = ""
+}
+
 variable "image_tag" {
   description = "Initial image tag used on `terraform apply`. After first apply, GitHub Actions updates the running tag; Terraform ignores image drift."
   type        = string


### PR DESCRIPTION
## Summary

Adds an `otlphttp/grafana` exporter to the Cloud Run collector sidecar so logs, metrics, and traces are forwarded to Grafana Cloud in parallel with the existing GCP backends. Grafana becomes a second visualization frontend without touching app code or removing the Cloud Logging / Cloud Trace / Cloud Monitoring path.

## Why

Grafana Cloud's OTel-native UI (Service Map, trace ↔ log ↔ metric correlation, exemplars) is meaningfully better for OTel-instrumented apps than what GCP exposes natively. The free tier (50 GB logs, 10K metric series, 50 GB traces) covers our current low-traffic load with margin.

Keeping the GCP exporters in place means we lose nothing by trying Grafana, and we can drop either side later based on which one ends up being used.

## Changes

- `Deploy/cloud-run/collector-config.yaml`
  - Add `otlphttp/grafana` exporter referencing `${env:GRAFANA_OTLP_ENDPOINT}` and `${env:GRAFANA_OTLP_AUTH}`.
  - Add it to all three pipelines (logs / traces / metrics/otlp) alongside the existing GCP exporters.
- `Terraform/secrets.tf`
  - New `google_secret_manager_secret.grafana_otlp_auth` (container only; the value is uploaded out-of-band like the other app secrets).
  - Runtime SA IAM binding for that secret.
- `Terraform/cloud_run.tf`
  - Inject `GRAFANA_OTLP_ENDPOINT` (plaintext, from var) and `GRAFANA_OTLP_AUTH` (Secret Manager) into the collector container.
  - Add the new IAM binding to `depends_on`.
- `Terraform/variables.tf`
  - `grafana_otlp_endpoint` (string, default `""` → exporter effectively disabled if unset).
  - `grafana_otlp_auth_secret_id` (default `GRAFANA_OTLP_AUTH`).
- `Terraform/terraform.tfvars.example`, `Terraform/README.md`
  - Document the operator workflow (sign-up → token → upload secret → set tfvar).

## Operator setup

1. Sign up at https://grafana.com (free tier).
2. Grafana Cloud Portal → Stack → **Connections** → **OpenTelemetry (OTLP)** → **Configure** to get the endpoint and create an API token.
3. Upload the Basic-auth header value:
   ```sh
   printf '%s' "$INSTANCE_ID:$API_TOKEN" | base64 | \
     gcloud secrets versions add GRAFANA_OTLP_AUTH --data-file=-
   ```
4. Set in `terraform.tfvars`:
   ```hcl
   grafana_otlp_endpoint = "https://otlp-gateway-prod-<region>.grafana.net/otlp"
   ```
5. `terraform apply`.

## Test plan

- [ ] `terraform plan` shows the new secret + IAM binding + collector env additions, no unintended drift
- [ ] After deploy, Cloud Run collector logs show no `otlphttp/grafana` errors
- [ ] Grafana Cloud → Drilldown → Traces shows entries with `service.name=blindlog-api`
- [ ] Grafana Cloud → Drilldown → Logs shows structured entries with `event.name`
- [ ] Cloud Trace / Cloud Logging / Cloud Monitoring continue to receive data (regression check)
- [ ] Send a few requests and confirm both backends see the same latency

🤖 Generated with [Claude Code](https://claude.com/claude-code)