### PR TITLE
add upload image api

### DIFF
--- a/Database/init/create.sql
+++ b/Database/init/create.sql
@@ -53,3 +53,15 @@ CREATE TABLE public.user_profiles (
 );
 
 CREATE INDEX user_profiles_latest_idx ON public.user_profiles(user_id, created_at DESC, id DESC);
+
+CREATE TABLE public.images (
+  id uuid NOT NULL,
+  user_id uuid NOT NULL,
+  cloudflare_image_id text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT images_pk PRIMARY KEY (id),
+  CONSTRAINT images_user_fk FOREIGN KEY (user_id) REFERENCES public.users (id) ON DELETE CASCADE,
+  CONSTRAINT images_cloudflare_image_id_key UNIQUE (cloudflare_image_id)
+);
+
+CREATE INDEX images_user_id_idx ON public.images(user_id);

--- a/Package.swift
+++ b/Package.swift
@@ -49,6 +49,7 @@ let package = Package(
         .product(name: "JWTKit", package: "jwt-kit"),
         .product(name: "Records", package: "swift-records"),
         .product(name: "CloudflareEmailService", package: "cloudflare-swift"),
+        .product(name: "CloudflareImages", package: "cloudflare-swift"),
         .product(name: "UUIDV7", package: "UUIDV7"),
         .product(name: "OTel", package: "swift-otel"),
       ],

--- a/Sources/App/API/API.swift
+++ b/Sources/App/API/API.swift
@@ -10,6 +10,7 @@ import WebAuthn
 struct API: APIProtocol {
   var cache: ValkeyClient
   var database: PostgresClient
+  var cloudflareImagesClient: any CloudflareImagesClientProtocol
   var jwtKeyCollection: JWTKeyCollection
   var webAuthn: WebAuthnManager
   var appleAppSiteAssociation: AppleAppSiteAssociation

--- a/Sources/App/API/CloudflareImagesClient.swift
+++ b/Sources/App/API/CloudflareImagesClient.swift
@@ -1,0 +1,37 @@
+import AsyncHTTPClient
+import Foundation
+import Images
+
+protocol CloudflareImagesClientProtocol: Sendable {
+  func createDirectUploadURL(userID: UUID) async throws -> CloudflareDirectUpload
+  func verifyUploadedImage(id: String, userID: UUID) async throws
+}
+
+struct CloudflareDirectUpload: Sendable, Hashable {
+  var id: String
+  var uploadURL: URL
+}
+
+struct CloudflareImagesClient: CloudflareImagesClientProtocol {
+  var client: Images.Client<AsyncHTTPClient.HTTPClient>
+
+  func createDirectUploadURL(userID: UUID) async throws -> CloudflareDirectUpload {
+    let result = try await client.createAuthenticatedUploadURL(
+      metadatas: ["userID": userID.uuidString],
+      requireSignedURLs: false
+    )
+    return CloudflareDirectUpload(id: result.id, uploadURL: result.uploadURL)
+  }
+
+  func verifyUploadedImage(id: String, userID: UUID) async throws {
+    let image = try await client.image(id: id)
+    guard image.metadatas?["userID"] == userID.uuidString else {
+      throw CloudflareImageVerificationError()
+    }
+    guard !image.requireSignedURLs else {
+      throw CloudflareImageVerificationError()
+    }
+  }
+}
+
+struct CloudflareImageVerificationError: Error {}

--- a/Sources/App/API/Images.swift
+++ b/Sources/App/API/Images.swift
@@ -1,0 +1,119 @@
+import Foundation
+import Hummingbird
+import PostgresNIO
+import Records
+import SQLKit
+import UUIDV7
+
+extension API {
+  func createImageUploadURL(
+    _ input: Operations.CreateImageUploadURL.Input
+  ) async throws -> Operations.CreateImageUploadURL.Output {
+    guard let userID = UserTokenContext.currentUserID else {
+      return .unauthorized
+    }
+
+    let upload: CloudflareDirectUpload
+    do {
+      upload = try await cloudflareImagesClient.createDirectUploadURL(userID: userID)
+    } catch {
+      AppRequestContext.current?.logger.appError(
+        eventName: "image.upload_url_create_failed",
+        "Failed to create Cloudflare Images upload URL",
+        metadata: ["cloudflare.operation": .string("images.direct_upload")],
+        error: error
+      )
+      return .badRequest
+    }
+
+    return .ok(.init(body: .json(.init(upload))))
+  }
+
+  func createImage(
+    _ input: Operations.CreateImage.Input
+  ) async throws -> Operations.CreateImage.Output {
+    guard let userID = UserTokenContext.currentUserID else {
+      return .unauthorized
+    }
+
+    guard case .json(let bodyData) = input.body else {
+      return .badRequest
+    }
+
+    let savedImage: ImageRecord?
+    do {
+      let existingImage = try await database.read { db in
+        try await ImageRecord
+          .where({ $0.cloudflareImageID.eq(bodyData.imageID) })
+          .limit(1)
+          .fetchOne(db)
+      }
+      if let existingImage {
+        guard existingImage.userID == userID else {
+          return .badRequest
+        }
+        return .ok(.init(body: .json(.init(existingImage))))
+      }
+
+      try await cloudflareImagesClient.verifyUploadedImage(id: bodyData.imageID, userID: userID)
+
+      savedImage = try await database.write { db in
+        let image = ImageRecord(
+          id: UUID(uuidString: UUID.uuidV7String())!,
+          userID: userID,
+          cloudflareImageID: bodyData.imageID,
+          createdAt: Date()
+        )
+
+        try await ImageRecord.insert { image } onConflict: {
+          $0.cloudflareImageID
+        }
+        .execute(db)
+
+        return try await ImageRecord
+          .where({ $0.cloudflareImageID.eq(bodyData.imageID) })
+          .limit(1)
+          .fetchOne(db)
+      }
+    } catch {
+      AppRequestContext.current?.logger.appError(
+        eventName: "image.create_failed",
+        "Failed to verify or persist image",
+        metadata: AppLogMetadata.userID(userID).merging([
+          "db.operation": .string("insert"),
+          "image.id": .string(bodyData.imageID),
+        ]) { _, new in new },
+        error: error
+      )
+      return .badRequest
+    }
+
+    guard let savedImage else {
+      return .badRequest
+    }
+    guard savedImage.userID == userID else {
+      return .badRequest
+    }
+
+    return .ok(.init(body: .json(.init(savedImage))))
+  }
+}
+
+extension Components.Schemas.CreateImageUploadURLResponse {
+  init(_ upload: CloudflareDirectUpload) {
+    self.init(
+      imageID: upload.id,
+      uploadURL: upload.uploadURL.absoluteString
+    )
+  }
+}
+
+extension Components.Schemas.Image {
+  init(_ image: ImageRecord) {
+    self.init(
+      id: image.id.uuidString,
+      imageID: image.cloudflareImageID,
+      createdAt: image.createdAt.timeIntervalSinceReferenceDate
+    )
+  }
+}

--- a/Sources/App/API/Images.swift
+++ b/Sources/App/API/Images.swift
@@ -65,12 +65,15 @@ extension API {
           createdAt: Date()
         )
 
-        try await ImageRecord.insert { image } onConflict: {
+        try await ImageRecord.insert {
+          image
+        } onConflict: {
           $0.cloudflareImageID
         }
         .execute(db)
 
-        return try await ImageRecord
+        return
+          try await ImageRecord
           .where({ $0.cloudflareImageID.eq(bodyData.imageID) })
           .limit(1)
           .fetchOne(db)

--- a/Sources/App/BuildApplication.swift
+++ b/Sources/App/BuildApplication.swift
@@ -6,6 +6,7 @@ import Foundation
 import HTTPClient
 import Hummingbird
 import HummingbirdPostgres
+import Images
 import JWTKit
 import Logging
 import OTel
@@ -31,7 +32,8 @@ private struct AlreadyBootstrappedObservabilityService: Service {
 }
 
 func buildApplication(
-  _ arguments: some AppArguments
+  _ arguments: some AppArguments,
+  cloudflareImagesClient: (any CloudflareImagesClientProtocol)? = nil
 ) async throws -> some ApplicationProtocol {
   let config = ConfigReader(providers: [EnvironmentVariablesProvider()])
 
@@ -87,6 +89,7 @@ func buildApplication(
   let api = try API(
     cache: cache,
     database: databaseClient,
+    cloudflareImagesClient: cloudflareImagesClient ?? makeCloudflareImagesClient(config: config),
     jwtKeyCollection: jwtKeyCollection,
     webAuthn: makeWebAuth(config: config),
     appleAppSiteAssociation: makeAppleAppSiteAssociation(config: config),
@@ -280,5 +283,18 @@ func makeCloudflareEmailService(
     accountId: config.requiredString(forKey: "account.id"),
     apiToken: config.requiredString(forKey: "api.token"),
     httpClient: .asyncHTTPClient(.shared)
+  )
+}
+
+func makeCloudflareImagesClient(
+  config: ConfigReader
+) throws -> any CloudflareImagesClientProtocol {
+  let config = config.scoped(to: "cloudflare")
+  return CloudflareImagesClient(
+    client: Images.Client(
+      accountId: try config.requiredString(forKey: "account.id"),
+      apiToken: try config.requiredString(forKey: "api.token"),
+      httpClient: .asyncHTTPClient(.shared)
+    )
   )
 }

--- a/Sources/App/Model/ImageRecord.swift
+++ b/Sources/App/Model/ImageRecord.swift
@@ -1,0 +1,10 @@
+import Foundation
+import Records
+
+@Table("images")
+struct ImageRecord: Codable, Identifiable, Hashable {
+  var id: UUID
+  @Column("user_id") var userID: UUID
+  @Column("cloudflare_image_id") var cloudflareImageID: String
+  @Column("created_at") var createdAt: Date
+}

--- a/Sources/App/openapi.yaml
+++ b/Sources/App/openapi.yaml
@@ -221,6 +221,44 @@ paths:
           description: A bad request
         '401':
           description: Not Authorization
+  /images/upload_url:
+    post:
+      operationId: createImageUploadURL
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: A success response with a direct image upload URL.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateImageUploadURLResponse'
+        '400':
+          description: A bad request
+        '401':
+          description: Not Authorization
+  /images:
+    post:
+      operationId: createImage
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateImageRequest'
+      responses:
+        '200':
+          description: A success response with the registered image.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Image'
+        '400':
+          description: A bad request
+        '401':
+          description: Not Authorization
   /users:
     get:
       operationId: getUsers
@@ -376,6 +414,47 @@ components:
           description: User profile name.
       required:
         - name
+    CreateImageUploadURLResponse:
+      type: object
+      description: A response with a Cloudflare Images direct upload URL.
+      properties:
+        imageID:
+          type: string
+          description: Cloudflare Images image id.
+        uploadURL:
+          type: string
+          description: Cloudflare Images direct upload URL.
+      required:
+        - imageID
+        - uploadURL
+    CreateImageRequest:
+      type: object
+      description: A request to register an uploaded image.
+      properties:
+        imageID:
+          type: string
+          description: Cloudflare Images image id.
+      required:
+        - imageID
+    Image:
+      type: object
+      description: A value with the uploaded image contents.
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Image id.
+        imageID:
+          type: string
+          description: Cloudflare Images image id.
+        createdAt:
+          type: number
+          format: double
+          description: Image registered date.
+      required:
+        - id
+        - imageID
+        - createdAt
     AppleAppSiteAssociation:
       type: object
       description: Apple App Site Association document.

--- a/Tests/AppTests/RouterTests.swift
+++ b/Tests/AppTests/RouterTests.swift
@@ -233,6 +233,174 @@ struct RouterTests {
   }
 
   @Test
+  func imageUploadRequiresAuthentication() async throws {
+    let arguments = TestArguments()
+    let app = try await buildApplication(
+      arguments,
+      cloudflareImagesClient: TestCloudflareImagesClient()
+    )
+    let ipAddress = UUID().uuidString
+
+    try await app.test(.router) { client in
+      let uploadURLResponse = try await client.execute(
+        uri: "/images/upload_url",
+        method: .post,
+        headers: [
+          .cfConnectingIP: ipAddress
+        ]
+      )
+      #expect(uploadURLResponse.status == .unauthorized)
+
+      let imageResponse = try await client.execute(
+        uri: "/images",
+        method: .post,
+        headers: [
+          .cfConnectingIP: ipAddress
+        ],
+        body: ByteBuffer(data: JSONEncoder().encode(["imageID": "cloudflare-image-id"]))
+      )
+      #expect(imageResponse.status == .unauthorized)
+    }
+  }
+
+  @Test
+  func createImageUploadURL() async throws {
+    let arguments = TestArguments()
+    let app = try await buildApplication(
+      arguments,
+      cloudflareImagesClient: TestCloudflareImagesClient(
+        directUpload: .init(
+          id: "cloudflare-image-id",
+          uploadURL: URL(string: "https://upload.imagedelivery.net/direct-upload")!
+        )
+      )
+    )
+    let ipAddress = UUID().uuidString
+
+    try await app.test(.router) { client in
+      let newUserResponse = try await client.execute(
+        uri: "/user",
+        method: .post,
+        headers: [
+          .cfConnectingIP: ipAddress
+        ]
+      )
+      #expect(newUserResponse.status == .ok)
+      let newUser = try JSONDecoder().decode(
+        Components.Schemas.UserToken.self,
+        from: newUserResponse.body
+      )
+
+      try await client.execute(
+        uri: "/images/upload_url",
+        method: .post,
+        headers: [
+          .cfConnectingIP: ipAddress,
+          .authorization: "Bearer \(newUser.token)",
+        ]
+      ) { response in
+        #expect(response.status == .ok)
+        let upload = try JSONDecoder().decode(
+          Components.Schemas.CreateImageUploadURLResponse.self,
+          from: response.body
+        )
+        #expect(upload.imageID == "cloudflare-image-id")
+        #expect(upload.uploadURL == "https://upload.imagedelivery.net/direct-upload")
+      }
+    }
+  }
+
+  @Test
+  func createImageRegistersUploadedImageIdempotently() async throws {
+    let arguments = TestArguments()
+    let app = try await buildApplication(
+      arguments,
+      cloudflareImagesClient: TestCloudflareImagesClient()
+    )
+    let ipAddress = UUID().uuidString
+
+    try await app.test(.router) { client in
+      let newUserResponse = try await client.execute(
+        uri: "/user",
+        method: .post,
+        headers: [
+          .cfConnectingIP: ipAddress
+        ]
+      )
+      #expect(newUserResponse.status == .ok)
+      let newUser = try JSONDecoder().decode(
+        Components.Schemas.UserToken.self,
+        from: newUserResponse.body
+      )
+
+      let firstImage = try await client.execute(
+        uri: "/images",
+        method: .post,
+        headers: [
+          .cfConnectingIP: ipAddress,
+          .authorization: "Bearer \(newUser.token)",
+        ],
+        body: ByteBuffer(data: JSONEncoder().encode(["imageID": "cloudflare-image-id"]))
+      ) { response in
+        #expect(response.status == .ok)
+        return try JSONDecoder().decode(Components.Schemas.Image.self, from: response.body)
+      }
+      #expect(firstImage.imageID == "cloudflare-image-id")
+
+      let secondImage = try await client.execute(
+        uri: "/images",
+        method: .post,
+        headers: [
+          .cfConnectingIP: ipAddress,
+          .authorization: "Bearer \(newUser.token)",
+        ],
+        body: ByteBuffer(data: JSONEncoder().encode(["imageID": "cloudflare-image-id"]))
+      ) { response in
+        #expect(response.status == .ok)
+        return try JSONDecoder().decode(Components.Schemas.Image.self, from: response.body)
+      }
+      #expect(secondImage.id == firstImage.id)
+      #expect(secondImage.imageID == firstImage.imageID)
+    }
+  }
+
+  @Test
+  func createImageRejectsCloudflareVerificationFailure() async throws {
+    let arguments = TestArguments()
+    let app = try await buildApplication(
+      arguments,
+      cloudflareImagesClient: TestCloudflareImagesClient(verifyError: TestCloudflareImagesError())
+    )
+    let ipAddress = UUID().uuidString
+
+    try await app.test(.router) { client in
+      let newUserResponse = try await client.execute(
+        uri: "/user",
+        method: .post,
+        headers: [
+          .cfConnectingIP: ipAddress
+        ]
+      )
+      #expect(newUserResponse.status == .ok)
+      let newUser = try JSONDecoder().decode(
+        Components.Schemas.UserToken.self,
+        from: newUserResponse.body
+      )
+
+      let response = try await client.execute(
+        uri: "/images",
+        method: .post,
+        headers: [
+          .cfConnectingIP: ipAddress,
+          .authorization: "Bearer \(newUser.token)",
+        ],
+        body: ByteBuffer(data: JSONEncoder().encode(["imageID": "missing-image-id"]))
+      )
+      #expect(response.status == .badRequest)
+    }
+  }
+
+  @Test
   func createAndGetUsers() async throws {
     let arguments = TestArguments()
     let app = try await buildApplication(arguments)
@@ -592,3 +760,27 @@ struct RouterTests {
     }
   }
 }
+
+private struct TestCloudflareImagesClient: CloudflareImagesClientProtocol {
+  var directUpload: CloudflareDirectUpload = .init(
+    id: "cloudflare-image-id",
+    uploadURL: URL(string: "https://upload.imagedelivery.net/direct-upload")!
+  )
+  var directUploadError: TestCloudflareImagesError?
+  var verifyError: TestCloudflareImagesError?
+
+  func createDirectUploadURL(userID: UUID) async throws -> CloudflareDirectUpload {
+    if let directUploadError {
+      throw directUploadError
+    }
+    return directUpload
+  }
+
+  func verifyUploadedImage(id: String, userID: UUID) async throws {
+    if let verifyError {
+      throw verifyError
+    }
+  }
+}
+
+private struct TestCloudflareImagesError: Error {}


### PR DESCRIPTION
## Summary

Cloudflare Images Direct Creator Upload を使った画像アップロードAPIを追加します。

- `POST /images/upload_url` を追加
  - 認証必須
  - Cloudflare Images の Direct Creator Upload URL を発行
  - `requireSignedURLs=false` 固定で公開画像として扱う
  - この時点ではDBへ書き込まない
- `POST /images` を追加
  - 認証必須
  - `imageID` を受け取り、Cloudflare Images APIでアップロード済み画像を確認
  - 確認後に `images` テーブルへ保存
  - 同じ `imageID` の再登録は冪等に既存レコードを返す
- `images` テーブルを追加
  - `id uuid primary key`
  - `user_id uuid not null references users(id) on delete cascade`
  - `cloudflare_image_id text not null unique`
  - `created_at timestamptz not null default now()`
- `cloudflare-swift` の `CloudflareImages` product を追加
- OpenAPI schema と RouterTests を追加

## Notes

- `POST /images/upload_url` ではDBに書かず、`POST /images` の完了登録時だけ `images` に保存します。
- Direct Upload URL発行時にCloudflare metadataへ `userID` を入れ、登録時に同じユーザー由来の画像か確認します。

## Test

- [x] `swift build`
- [ ] `swift test --filter RouterTests/createImage`
  - テストターゲットのビルドは通過
  - ローカル実行は `valkey.hostname` 未設定でアプリ起動前に停止
