### PR TITLE
add image id for user_profiles

### DIFF
--- a/Database/init/create.sql
+++ b/Database/init/create.sql
@@ -42,18 +42,6 @@ CREATE TABLE public.user_email (
   CONSTRAINT user_email_user_fk FOREIGN KEY (user_id) REFERENCES public.users (id) ON DELETE CASCADE
 );
 
-CREATE TABLE public.user_profiles (
-  id uuid NOT NULL,
-  user_id uuid NOT NULL,
-  name text NOT NULL,
-  created_at timestamptz NOT NULL DEFAULT now(),
-  CONSTRAINT user_profiles_pk PRIMARY KEY (id),
-  CONSTRAINT user_profiles_user_fk FOREIGN KEY (user_id) REFERENCES public.users (id) ON DELETE CASCADE,
-  CONSTRAINT user_profiles_name_length CHECK (char_length(trim(name)) BETWEEN 1 AND 100)
-);
-
-CREATE INDEX user_profiles_latest_idx ON public.user_profiles(user_id, created_at DESC, id DESC);
-
 CREATE TABLE public.images (
   id uuid NOT NULL,
   user_id uuid NOT NULL,
@@ -65,3 +53,17 @@ CREATE TABLE public.images (
 );
 
 CREATE INDEX images_user_id_idx ON public.images(user_id);
+
+CREATE TABLE public.user_profiles (
+  id uuid NOT NULL,
+  user_id uuid NOT NULL,
+  image_id uuid,
+  name text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT user_profiles_pk PRIMARY KEY (id),
+  CONSTRAINT user_profiles_user_fk FOREIGN KEY (user_id) REFERENCES public.users (id) ON DELETE CASCADE,
+  CONSTRAINT user_profiles_image_fk FOREIGN KEY (image_id) REFERENCES public.images (id),
+  CONSTRAINT user_profiles_name_length CHECK (char_length(trim(name)) BETWEEN 1 AND 100)
+);
+
+CREATE INDEX user_profiles_latest_idx ON public.user_profiles(user_id, created_at DESC, id DESC);

--- a/Sources/App/API/UserProfile.swift
+++ b/Sources/App/API/UserProfile.swift
@@ -138,8 +138,8 @@ extension Components.Schemas.UserProfile {
     self.init(
       id: profile.id.uuidString,
       userID: profile.userID.uuidString,
-      imageID: profile.imageID?.uuidString,
       name: profile.name,
+      imageID: profile.imageID?.uuidString,
       createdAt: profile.createdAt.timeIntervalSinceReferenceDate
     )
   }

--- a/Sources/App/API/UserProfile.swift
+++ b/Sources/App/API/UserProfile.swift
@@ -53,9 +53,38 @@ extension API {
       return .badRequest
     }
 
+    let imageID: UUID?
+    if let requestedImageID = bodyData.imageID {
+      guard let parsedImageID = UUID(uuidString: requestedImageID) else {
+        return .badRequest
+      }
+
+      do {
+        guard try await imageBelongsToUser(imageID: parsedImageID, userID: userID) else {
+          return .badRequest
+        }
+      } catch {
+        AppRequestContext.current?.logger.appError(
+          eventName: "user.profile_image_read_failed",
+          "Failed to fetch user profile image",
+          metadata: AppLogMetadata.userID(userID).merging([
+            "db.operation": .string("select"),
+            "image.id": .string(requestedImageID),
+          ]) { _, new in new },
+          error: error
+        )
+        return .badRequest
+      }
+
+      imageID = parsedImageID
+    } else {
+      imageID = nil
+    }
+
     let profile = UserProfileRecord(
       id: UUID(uuidString: UUID.uuidV7String())!,
       userID: userID,
+      imageID: imageID,
       name: name,
       createdAt: Date()
     )
@@ -90,6 +119,18 @@ extension API {
         .fetchOne(db)
     }
   }
+
+  fileprivate func imageBelongsToUser(imageID: UUID, userID: UUID) async throws -> Bool {
+    try await database.read { db in
+      try await ImageRecord
+        .where {
+          $0.id.eq(imageID)
+            .and($0.userID.eq(userID))
+        }
+        .limit(1)
+        .fetchOne(db) != nil
+    }
+  }
 }
 
 extension Components.Schemas.UserProfile {
@@ -97,6 +138,7 @@ extension Components.Schemas.UserProfile {
     self.init(
       id: profile.id.uuidString,
       userID: profile.userID.uuidString,
+      imageID: profile.imageID?.uuidString,
       name: profile.name,
       createdAt: profile.createdAt.timeIntervalSinceReferenceDate
     )

--- a/Sources/App/Model/UserProfileRecord.swift
+++ b/Sources/App/Model/UserProfileRecord.swift
@@ -5,6 +5,7 @@ import Records
 struct UserProfileRecord: Codable, Identifiable, Hashable {
   var id: UUID
   @Column("user_id") var userID: UUID
+  @Column("image_id") var imageID: UUID?
   var name: String
   @Column("created_at") var createdAt: Date
 }

--- a/Tests/AppTests/RouterTests.swift
+++ b/Tests/AppTests/RouterTests.swift
@@ -244,10 +244,12 @@ struct RouterTests {
           .cfConnectingIP: ipAddress,
           .authorization: "Bearer \(newUser.token)",
         ],
-        body: ByteBuffer(data: JSONEncoder().encode([
-          "name": "Alice",
-          "imageID": image.id,
-        ]))
+        body: ByteBuffer(
+          data: JSONEncoder().encode([
+            "name": "Alice",
+            "imageID": image.id,
+          ])
+        )
       ) { response in
         #expect(response.status == .ok)
         return try JSONDecoder().decode(Components.Schemas.UserProfile.self, from: response.body)
@@ -325,10 +327,12 @@ struct RouterTests {
           .cfConnectingIP: ipAddress,
           .authorization: "Bearer \(secondUser.token)",
         ],
-        body: ByteBuffer(data: JSONEncoder().encode([
-          "name": "Bob",
-          "imageID": image.id,
-        ]))
+        body: ByteBuffer(
+          data: JSONEncoder().encode([
+            "name": "Bob",
+            "imageID": image.id,
+          ])
+        )
       )
       #expect(response.status == .badRequest)
     }

--- a/Tests/AppTests/RouterTests.swift
+++ b/Tests/AppTests/RouterTests.swift
@@ -162,6 +162,7 @@ struct RouterTests {
       }
       #expect(firstProfile.userID == newUser.userID)
       #expect(firstProfile.name == "Alice")
+      #expect(firstProfile.imageID == nil)
 
       let secondProfile = try await client.execute(
         uri: "/user_profile",
@@ -177,6 +178,7 @@ struct RouterTests {
       }
       #expect(firstProfile.id != secondProfile.id)
       #expect(secondProfile.name == "Bob")
+      #expect(secondProfile.imageID == nil)
 
       try await client.execute(
         uri: "/user_profile",
@@ -193,7 +195,142 @@ struct RouterTests {
         )
         #expect(profile.id == secondProfile.id)
         #expect(profile.name == "Bob")
+        #expect(profile.imageID == nil)
       }
+    }
+  }
+
+  @Test
+  func userProfileCanReferenceOwnImage() async throws {
+    let arguments = TestArguments()
+    let app = try await buildApplication(
+      arguments,
+      cloudflareImagesClient: TestCloudflareImagesClient()
+    )
+    let ipAddress = UUID().uuidString
+    let cloudflareImageID = UUID().uuidString
+
+    try await app.test(.router) { client in
+      let newUserResponse = try await client.execute(
+        uri: "/user",
+        method: .post,
+        headers: [
+          .cfConnectingIP: ipAddress
+        ]
+      )
+      #expect(newUserResponse.status == .ok)
+      let newUser = try JSONDecoder().decode(
+        Components.Schemas.UserToken.self,
+        from: newUserResponse.body
+      )
+
+      let image = try await client.execute(
+        uri: "/images",
+        method: .post,
+        headers: [
+          .cfConnectingIP: ipAddress,
+          .authorization: "Bearer \(newUser.token)",
+        ],
+        body: ByteBuffer(data: JSONEncoder().encode(["imageID": cloudflareImageID]))
+      ) { response in
+        #expect(response.status == .ok)
+        return try JSONDecoder().decode(Components.Schemas.Image.self, from: response.body)
+      }
+
+      let profile = try await client.execute(
+        uri: "/user_profile",
+        method: .post,
+        headers: [
+          .cfConnectingIP: ipAddress,
+          .authorization: "Bearer \(newUser.token)",
+        ],
+        body: ByteBuffer(data: JSONEncoder().encode([
+          "name": "Alice",
+          "imageID": image.id,
+        ]))
+      ) { response in
+        #expect(response.status == .ok)
+        return try JSONDecoder().decode(Components.Schemas.UserProfile.self, from: response.body)
+      }
+      #expect(profile.imageID == image.id)
+
+      try await client.execute(
+        uri: "/user_profile",
+        method: .get,
+        headers: [
+          .cfConnectingIP: ipAddress,
+          .authorization: "Bearer \(newUser.token)",
+        ]
+      ) { response in
+        #expect(response.status == .ok)
+        let latestProfile = try JSONDecoder().decode(
+          Components.Schemas.UserProfile.self,
+          from: response.body
+        )
+        #expect(latestProfile.id == profile.id)
+        #expect(latestProfile.imageID == image.id)
+      }
+    }
+  }
+
+  @Test
+  func userProfileRejectsOtherUsersImage() async throws {
+    let arguments = TestArguments()
+    let app = try await buildApplication(
+      arguments,
+      cloudflareImagesClient: TestCloudflareImagesClient()
+    )
+    let ipAddress = UUID().uuidString
+    let cloudflareImageID = UUID().uuidString
+
+    try await app.test(.router) { client in
+      let firstUser = try await client.execute(
+        uri: "/user",
+        method: .post,
+        headers: [
+          .cfConnectingIP: ipAddress
+        ]
+      ) { response in
+        #expect(response.status == .ok)
+        return try JSONDecoder().decode(Components.Schemas.UserToken.self, from: response.body)
+      }
+      let secondUser = try await client.execute(
+        uri: "/user",
+        method: .post,
+        headers: [
+          .cfConnectingIP: ipAddress
+        ]
+      ) { response in
+        #expect(response.status == .ok)
+        return try JSONDecoder().decode(Components.Schemas.UserToken.self, from: response.body)
+      }
+
+      let image = try await client.execute(
+        uri: "/images",
+        method: .post,
+        headers: [
+          .cfConnectingIP: ipAddress,
+          .authorization: "Bearer \(firstUser.token)",
+        ],
+        body: ByteBuffer(data: JSONEncoder().encode(["imageID": cloudflareImageID]))
+      ) { response in
+        #expect(response.status == .ok)
+        return try JSONDecoder().decode(Components.Schemas.Image.self, from: response.body)
+      }
+
+      let response = try await client.execute(
+        uri: "/user_profile",
+        method: .post,
+        headers: [
+          .cfConnectingIP: ipAddress,
+          .authorization: "Bearer \(secondUser.token)",
+        ],
+        body: ByteBuffer(data: JSONEncoder().encode([
+          "name": "Bob",
+          "imageID": image.id,
+        ]))
+      )
+      #expect(response.status == .badRequest)
     }
   }
 

--- a/public/documents/openapi.yml
+++ b/public/documents/openapi.yml
@@ -391,6 +391,10 @@ components:
           type: string
           format: uuid
           description: User id.
+        imageID:
+          type: string
+          format: uuid
+          description: Image id for the profile image.
         name:
           type: string
           description: User profile name.
@@ -412,6 +416,10 @@ components:
           minLength: 1
           maxLength: 100
           description: User profile name.
+        imageID:
+          type: string
+          format: uuid
+          description: Image id for the profile image.
       required:
         - name
     CreateImageUploadURLResponse:

--- a/public/documents/openapi.yml
+++ b/public/documents/openapi.yml
@@ -391,13 +391,13 @@ components:
           type: string
           format: uuid
           description: User id.
+        name:
+          type: string
+          description: User profile name.
         imageID:
           type: string
           format: uuid
           description: Image id for the profile image.
-        name:
-          type: string
-          description: User profile name.
         createdAt:
           type: number
           format: double


### PR DESCRIPTION
## Summary
- Add optional `imageID` to user profile request/response schemas.
- Store `image_id` on append-only `user_profiles` rows and reference `images(id)`.
- Validate that a requested profile image belongs to the authenticated user before creating a new profile row.

## DB Changes
- `user_profiles.image_id uuid` is nullable.
- `user_profiles_image_fk` references `public.images(id)`.
- `images` is created before `user_profiles` in `Database/init/create.sql` so fresh DB setup satisfies the FK order.