### PR TITLE
Update profile response shape and image URL handling

### DIFF
--- a/Sources/App/API/CloudflareImagesClient.swift
+++ b/Sources/App/API/CloudflareImagesClient.swift
@@ -5,6 +5,7 @@ import Images
 protocol CloudflareImagesClientProtocol: Sendable {
   func createDirectUploadURL(userID: UUID) async throws -> CloudflareDirectUpload
   func verifyUploadedImage(id: String, userID: UUID) async throws
+  func imageURL(id: String, userID: UUID) async throws -> URL
 }
 
 struct CloudflareDirectUpload: Sendable, Hashable {
@@ -24,14 +25,46 @@ struct CloudflareImagesClient: CloudflareImagesClientProtocol {
   }
 
   func verifyUploadedImage(id: String, userID: UUID) async throws {
+    _ = try await uploadedImage(id: id, userID: userID)
+  }
+
+  func imageURL(id: String, userID: UUID) async throws -> URL {
+    let image = try await uploadedImage(id: id, userID: userID)
+    guard let url = image.variants.first else {
+      throw CloudflareImageVerificationError.missingVariantURL
+    }
+    return url
+  }
+
+  private func uploadedImage(id: String, userID: UUID) async throws -> Image {
     let image = try await client.image(id: id)
-    guard image.metadatas?["userID"] == userID.uuidString else {
-      throw CloudflareImageVerificationError()
+    let imageUserID = image.metadatas?["userID"]
+    guard imageUserID == userID.uuidString else {
+      throw CloudflareImageVerificationError.userIDMetadataMismatch(
+        expected: userID.uuidString,
+        actual: imageUserID
+      )
     }
     guard !image.requireSignedURLs else {
-      throw CloudflareImageVerificationError()
+      throw CloudflareImageVerificationError.signedURLsRequired
     }
+    return image
   }
 }
 
-struct CloudflareImageVerificationError: Error {}
+enum CloudflareImageVerificationError: Error, CustomStringConvertible {
+  case userIDMetadataMismatch(expected: String, actual: String?)
+  case signedURLsRequired
+  case missingVariantURL
+
+  var description: String {
+    switch self {
+    case .userIDMetadataMismatch(let expected, let actual):
+      "Cloudflare image userID metadata mismatch. expected=\(expected), actual=\(actual ?? "nil")"
+    case .signedURLsRequired:
+      "Cloudflare image requires signed URLs."
+    case .missingVariantURL:
+      "Cloudflare image has no variant URL."
+    }
+  }
+}

--- a/Sources/App/API/ConfirmEmail.swift
+++ b/Sources/App/API/ConfirmEmail.swift
@@ -59,10 +59,9 @@ extension API {
     do {
       try await database.write { db in
         try await UserEmail.insert {
-          UserEmail(
-            userID: userID,
-            email: email
-          )
+          ($0.userID, $0.email)
+        } values: {
+          (userID, email)
         } onConflict: { columns in
           (columns.userID, columns.email)
         }.execute(db)

--- a/Sources/App/API/GetMe.swift
+++ b/Sources/App/API/GetMe.swift
@@ -12,23 +12,6 @@ extension API {
       return .unauthorized
     }
 
-    let profile: Components.Schemas.UserProfile?
-    do {
-      profile = try await getProfile(userID: userID)
-    } catch {
-      AppRequestContext.current?.logger.appError(
-        eventName: "user.profile_read_failed",
-        "Failed to fetch user profile",
-        metadata: AppLogMetadata.userID(userID).merging([
-          "db.operation": .string("select")
-        ]) { _, new in new },
-        error: error
-      )
-      return .badRequest
-    }
-
-    guard let profile else { return .notFound }
-
     let emails: [UserEmail]
     do {
       emails = try await registeredEmails(userID: userID)
@@ -44,7 +27,22 @@ extension API {
       return .badRequest
     }
 
-    return .ok(.init(body: .json(.init(profile, emails: emails))))
+    let profile: Components.Schemas.UserProfile?
+    do {
+      profile = try await getProfile(userID: userID)
+    } catch {
+      AppRequestContext.current?.logger.appError(
+        eventName: "user.profile_read_failed",
+        "Failed to fetch user profile",
+        metadata: AppLogMetadata.userID(userID).merging([
+          "db.operation": .string("select")
+        ]) { _, new in new },
+        error: error
+      )
+      return .badRequest
+    }
+
+    return .ok(.init(body: .json(.init(userID: userID, profile: profile, emails: emails))))
   }
 
   fileprivate func registeredEmails(userID: UUID) async throws -> [UserEmail] {
@@ -58,14 +56,21 @@ extension API {
 }
 
 extension Components.Schemas.Me {
-  fileprivate init(_ profile: Components.Schemas.UserProfile, emails: [UserEmail]) {
+  fileprivate init(userID: UUID, profile: Components.Schemas.UserProfile?, emails: [UserEmail]) {
     self.init(
-      id: profile.id,
-      userID: profile.userID,
+      userID: userID.uuidString,
+      userProfile: profile.map { .init(value1: .init($0)) },
+      emails: emails.map { .init($0) }
+    )
+  }
+}
+
+extension Components.Schemas.MeUserProfile {
+  fileprivate init(_ profile: Components.Schemas.UserProfile) {
+    self.init(
       name: profile.name,
       imageURL: profile.imageURL,
-      createdAt: profile.createdAt,
-      emails: emails.map { .init($0) }
+      createdAt: profile.createdAt
     )
   }
 }

--- a/Sources/App/API/GetMe.swift
+++ b/Sources/App/API/GetMe.swift
@@ -1,6 +1,10 @@
 import Foundation
 import Hummingbird
 import Logging
+import PostgresNIO
+import Records
+import SQLKit
+import StructuredQueriesPostgres
 
 extension API {
   func getMe(_ input: Operations.GetMe.Input) async throws -> Operations.GetMe.Output {
@@ -25,6 +29,52 @@ extension API {
 
     guard let profile else { return .notFound }
 
-    return .ok(.init(body: .json(profile)))
+    let emails: [UserEmail]
+    do {
+      emails = try await registeredEmails(userID: userID)
+    } catch {
+      AppRequestContext.current?.logger.appError(
+        eventName: "user.email.list_failed",
+        "Failed to fetch registered emails",
+        metadata: AppLogMetadata.userID(userID).merging([
+          "db.operation": .string("select")
+        ]) { _, new in new },
+        error: error
+      )
+      return .badRequest
+    }
+
+    return .ok(.init(body: .json(.init(profile, emails: emails))))
+  }
+
+  fileprivate func registeredEmails(userID: UUID) async throws -> [UserEmail] {
+    try await database.read { db in
+      try await UserEmail
+        .where { $0.userID.eq(userID) }
+        .order { ($0.createdAt.asc(), $0.email.asc()) }
+        .fetchAll(db)
+    }
+  }
+}
+
+extension Components.Schemas.Me {
+  fileprivate init(_ profile: Components.Schemas.UserProfile, emails: [UserEmail]) {
+    self.init(
+      id: profile.id,
+      userID: profile.userID,
+      name: profile.name,
+      imageURL: profile.imageURL,
+      createdAt: profile.createdAt,
+      emails: emails.map { .init($0) }
+    )
+  }
+}
+
+extension Components.Schemas.Email {
+  fileprivate init(_ email: UserEmail) {
+    self.init(
+      email: email.email,
+      createdAt: email.createdAt.timeIntervalSinceReferenceDate
+    )
   }
 }

--- a/Sources/App/API/GetMe.swift
+++ b/Sources/App/API/GetMe.swift
@@ -1,105 +1,30 @@
 import Foundation
 import Hummingbird
-import PostgresKit
-import Records
-import SQLKit
-import Valkey
+import Logging
 
 extension API {
   func getMe(_ input: Operations.GetMe.Input) async throws -> Operations.GetMe.Output {
     guard let userID = UserTokenContext.currentUserID else {
       return .unauthorized
     }
-    let user: UserProfile?
+
+    let profile: Components.Schemas.UserProfile?
     do {
-      user = try await getUser(id: userID)
+      profile = try await getProfile(userID: userID)
     } catch {
       AppRequestContext.current?.logger.appError(
         eventName: "user.profile_read_failed",
         "Failed to fetch user profile",
-        metadata: AppLogMetadata.userID(userID),
+        metadata: AppLogMetadata.userID(userID).merging([
+          "db.operation": .string("select")
+        ]) { _, new in new },
         error: error
       )
       return .badRequest
     }
 
-    guard let user else {
-      return .notFound
-    }
+    guard let profile else { return .notFound }
 
-    let responseUser = Components.Schemas.User(
-      id: user.id.uuidString,
-      email: user.email
-    )
-
-    return .ok(.init(body: .json(responseUser)))
+    return .ok(.init(body: .json(profile)))
   }
-
-  fileprivate func getUser(id: UUID) async throws -> UserProfile? {
-    // 1. Get User from Cache and Update Expiration if exits
-    let cacheUser = try await getUserFromCacheAndUpdateExpiration(
-      id: id
-    )
-
-    if let cacheUser {
-      return cacheUser
-    }
-
-    // 2. Get User from DB that is not in Cache
-    let dbUser: UserProfile? = try await getUserFromDatabase(
-      id: id
-    )
-
-    guard let dbUser else { return nil }
-
-    // 3. Set New User to Cache
-    try await addUserToCache(
-      user: dbUser
-    )
-    return dbUser
-  }
-
-  fileprivate func addUserToCache(
-    user: UserProfile
-  ) async throws {
-    try await cache.set(
-      ValkeyKey("user:\(user.id.uuidString)"),
-      value: try JSONEncoder().encode(user),
-      expiration: .seconds(60 * 10)  // 10 minutes
-    )
-  }
-
-  fileprivate func getUserFromDatabase(
-    id: User.ID
-  ) async throws -> UserProfile? {
-    return try await database.read { db in
-      try await User
-        .leftJoin(UserEmail.all) { $0.0.id.eq($0.1.userID) }
-        .where { user, _ in user.id.eq(id) }
-        .select { UserProfile.Columns(id: $0.id, email: $1.email) }
-        .limit(1)
-        .fetchOne(db)
-    }
-  }
-
-  fileprivate func getUserFromCacheAndUpdateExpiration(
-    id: User.ID
-  ) async throws -> UserProfile? {
-    let userData = try await cache.getex(
-      ValkeyKey("user:\(id.uuidString)"),
-      expiration: .seconds(60 * 10)  // 10 minutes
-    )
-
-    if let userData {
-      return try JSONDecoder().decode(UserProfile.self, from: Data(userData))
-    } else {
-      return nil
-    }
-  }
-}
-
-@Selection
-struct UserProfile: Codable {
-  var id: UUID
-  var email: String?
 }

--- a/Sources/App/API/ImageCache.swift
+++ b/Sources/App/API/ImageCache.swift
@@ -1,0 +1,44 @@
+import Foundation
+import Valkey
+
+extension API {
+  func cachedImage(id: UUID) async throws -> ImageRecord? {
+    let imageData = try await cache.getex(
+      imageIDCacheKey(id),
+      expiration: .seconds(60 * 10)
+    )
+    guard let imageData else { return nil }
+    return try JSONDecoder().decode(ImageRecord.self, from: Data(imageData))
+  }
+
+  func cachedImage(cloudflareImageID: String) async throws -> ImageRecord? {
+    let imageData = try await cache.getex(
+      imageCloudflareIDCacheKey(cloudflareImageID),
+      expiration: .seconds(60 * 10)
+    )
+    guard let imageData else { return nil }
+    return try JSONDecoder().decode(ImageRecord.self, from: Data(imageData))
+  }
+
+  func cacheImage(_ image: ImageRecord) async throws {
+    let imageData = try JSONEncoder().encode(image)
+    try await cache.set(
+      imageIDCacheKey(image.id),
+      value: imageData,
+      expiration: .seconds(60 * 10)
+    )
+    try await cache.set(
+      imageCloudflareIDCacheKey(image.cloudflareImageID),
+      value: imageData,
+      expiration: .seconds(60 * 10)
+    )
+  }
+
+  func imageIDCacheKey(_ id: UUID) -> ValkeyKey {
+    ValkeyKey("image:id:\(id.uuidString)")
+  }
+
+  func imageCloudflareIDCacheKey(_ cloudflareImageID: String) -> ValkeyKey {
+    ValkeyKey("image:cloudflare_id:\(cloudflareImageID)")
+  }
+}

--- a/Sources/App/API/Images.swift
+++ b/Sources/App/API/Images.swift
@@ -40,6 +40,26 @@ extension API {
       return .badRequest
     }
 
+    do {
+      if let cachedImage = try await cachedImage(cloudflareImageID: bodyData.imageID) {
+        guard cachedImage.userID == userID else {
+          return .badRequest
+        }
+        return .ok(.init(body: .json(.init(cachedImage))))
+      }
+    } catch {
+      AppRequestContext.current?.logger.appLog(
+        level: .warning,
+        eventName: "image.cache_read_failed",
+        "Failed to fetch image from cache",
+        metadata: AppLogMetadata.userID(userID).merging([
+          "cache.operation": .string("getex"),
+          "image.id": .string(bodyData.imageID),
+        ]) { _, new in new },
+        error: error
+      )
+    }
+
     let savedImage: ImageRecord?
     do {
       let existingImage = try await database.read { db in
@@ -51,6 +71,20 @@ extension API {
       if let existingImage {
         guard existingImage.userID == userID else {
           return .badRequest
+        }
+        do {
+          try await cacheImage(existingImage)
+        } catch {
+          AppRequestContext.current?.logger.appLog(
+            level: .warning,
+            eventName: "image.cache_write_failed",
+            "Failed to write image to cache",
+            metadata: AppLogMetadata.userID(userID).merging([
+              "cache.operation": .string("set"),
+              "image.id": .string(existingImage.cloudflareImageID),
+            ]) { _, new in new },
+            error: error
+          )
         }
         return .ok(.init(body: .json(.init(existingImage))))
       }
@@ -96,6 +130,21 @@ extension API {
     }
     guard savedImage.userID == userID else {
       return .badRequest
+    }
+
+    do {
+      try await cacheImage(savedImage)
+    } catch {
+      AppRequestContext.current?.logger.appLog(
+        level: .warning,
+        eventName: "image.cache_write_failed",
+        "Failed to write image to cache",
+        metadata: AppLogMetadata.userID(userID).merging([
+          "cache.operation": .string("set"),
+          "image.id": .string(savedImage.cloudflareImageID),
+        ]) { _, new in new },
+        error: error
+      )
     }
 
     return .ok(.init(body: .json(.init(savedImage))))

--- a/Sources/App/API/UserProfile.swift
+++ b/Sources/App/API/UserProfile.swift
@@ -5,19 +5,23 @@ import PostgresNIO
 import Records
 import SQLKit
 import StructuredQueriesPostgres
+import Valkey
 import UUIDV7
 
 extension API {
   func getUserProfile(
     _ input: Operations.GetUserProfile.Input
   ) async throws -> Operations.GetUserProfile.Output {
-    guard let userID = UserTokenContext.currentUserID else {
+    guard UserTokenContext.currentUserID != nil else {
       return .unauthorized
     }
+    guard let userID = UUID(uuidString: input.path.userId) else {
+      return .badRequest
+    }
 
-    let profile: UserProfileRecord?
+    let profile: Components.Schemas.UserProfile?
     do {
-      profile = try await latestUserProfile(userID: userID)
+      profile = try await getProfile(userID: userID)
     } catch {
       AppRequestContext.current?.logger.appError(
         eventName: "user.profile_read_failed",
@@ -30,11 +34,9 @@ extension API {
       return .badRequest
     }
 
-    guard let profile else {
-      return .notFound
-    }
+    guard let profile else { return .notFound }
 
-    return .ok(.init(body: .json(.init(profile))))
+    return .ok(.init(body: .json(profile)))
   }
 
   func createUserProfile(
@@ -54,15 +56,22 @@ extension API {
     }
 
     let imageID: UUID?
+    let cloudflareImageID: String?
     if let requestedImageID = bodyData.imageID {
       guard let parsedImageID = UUID(uuidString: requestedImageID) else {
         return .badRequest
       }
 
       do {
-        guard try await imageBelongsToUser(imageID: parsedImageID, userID: userID) else {
+        guard
+          let imageCloudflareID = try await userImageCloudflareID(
+            imageID: parsedImageID,
+            userID: userID
+          )
+        else {
           return .badRequest
         }
+        cloudflareImageID = imageCloudflareID
       } catch {
         AppRequestContext.current?.logger.appError(
           eventName: "user.profile_image_read_failed",
@@ -79,6 +88,7 @@ extension API {
       imageID = parsedImageID
     } else {
       imageID = nil
+      cloudflareImageID = nil
     }
 
     let profile = UserProfileRecord(
@@ -105,42 +115,248 @@ extension API {
       return .badRequest
     }
 
-    return .ok(.init(body: .json(.init(profile))))
+    do {
+      let profileForCache = UserProfile(profile, cloudflareImageID: cloudflareImageID)
+      do {
+        try await replaceCachedLatestProfile(profileForCache, userID: userID)
+      } catch {
+        AppRequestContext.current?.logger.appLog(
+          level: .warning,
+          eventName: "user.profile_cache_write_failed",
+          "Failed to write latest user profile to cache",
+          metadata: AppLogMetadata.userID(userID).merging([
+            "cache.operation": .string("set")
+          ]) { _, new in new },
+          error: error
+        )
+      }
+
+      return .ok(
+        .init(
+          body: .json(
+            try await userProfileResponse(
+              profileForCache,
+              userID: userID
+            )
+          )
+        )
+      )
+    } catch {
+      AppRequestContext.current?.logger.appError(
+        eventName: "user.profile_image_url_read_failed",
+        "Failed to fetch user profile image URL",
+        metadata: AppLogMetadata.userID(userID).merging([
+          "cloudflare.operation": .string("images.image")
+        ]) { _, new in new },
+        error: error
+      )
+      return .badRequest
+    }
   }
 
-  fileprivate func latestUserProfile(userID: UUID) async throws -> UserProfileRecord? {
-    try await database.read { db in
+  func getProfile(userID: UUID) async throws -> Components.Schemas.UserProfile? {
+    do {
+      if let cachedProfile = try await cachedLatestProfile(userID: userID) {
+        return try await userProfileResponse(cachedProfile, userID: userID)
+      }
+    } catch {
+      AppRequestContext.current?.logger.appLog(
+        level: .warning,
+        eventName: "user.profile_cache_read_failed",
+        "Failed to fetch latest user profile from cache",
+        metadata: AppLogMetadata.userID(userID).merging([
+          "cache.operation": .string("getex")
+        ]) { _, new in new },
+        error: error
+      )
+    }
+
+    let profile = try await database.read { db in
       try await UserProfileRecord
-        .where { $0.userID.eq(userID) }
-        .order { profile in
+        .leftJoin(ImageRecord.all) { profile, image in
+          profile.imageID.eq(image.id)
+        }
+        .where { profile, _ in profile.userID.eq(userID) }
+        .order { profile, _ in
           (profile.createdAt.desc(), profile.id.desc())
+        }
+        .select { profile, image in
+          UserProfile.Columns(
+            id: profile.id,
+            userID: SQLQueryExpression<UUID?>(profile.userID.queryFragment),
+            name: SQLQueryExpression<String?>(profile.name.queryFragment),
+            cloudflareImageID: image.cloudflareImageID,
+            createdAt: SQLQueryExpression<Date?>(profile.createdAt.queryFragment)
+          )
         }
         .limit(1)
         .fetchOne(db)
     }
+
+    guard let profile else { return nil }
+
+    do {
+      try await cacheLatestProfile(profile, userID: userID)
+    } catch {
+      AppRequestContext.current?.logger.appLog(
+        level: .warning,
+        eventName: "user.profile_cache_write_failed",
+        "Failed to write latest user profile to cache",
+        metadata: AppLogMetadata.userID(userID).merging([
+          "cache.operation": .string("set")
+        ]) { _, new in new },
+        error: error
+      )
+    }
+
+    return try await userProfileResponse(profile, userID: userID)
   }
 
-  fileprivate func imageBelongsToUser(imageID: UUID, userID: UUID) async throws -> Bool {
-    try await database.read { db in
+  fileprivate func userImageCloudflareID(imageID: UUID, userID: UUID) async throws -> String? {
+    do {
+      if let cachedImage = try await cachedImage(id: imageID) {
+        guard cachedImage.userID == userID else { return nil }
+        return cachedImage.cloudflareImageID
+      }
+    } catch {
+      AppRequestContext.current?.logger.appLog(
+        level: .warning,
+        eventName: "image.cache_read_failed",
+        "Failed to fetch image from cache",
+        metadata: AppLogMetadata.userID(userID).merging([
+          "cache.operation": .string("getex"),
+          "image.uuid": .string(imageID.uuidString),
+        ]) { _, new in new },
+        error: error
+      )
+    }
+
+    let image = try await database.read { db in
       try await ImageRecord
         .where {
           $0.id.eq(imageID)
             .and($0.userID.eq(userID))
         }
         .limit(1)
-        .fetchOne(db) != nil
+        .fetchOne(db)
     }
+    guard let image else { return nil }
+
+    do {
+      try await cacheImage(image)
+    } catch {
+      AppRequestContext.current?.logger.appLog(
+        level: .warning,
+        eventName: "image.cache_write_failed",
+        "Failed to write image to cache",
+        metadata: AppLogMetadata.userID(userID).merging([
+          "cache.operation": .string("set"),
+          "image.uuid": .string(imageID.uuidString),
+        ]) { _, new in new },
+        error: error
+      )
+    }
+
+    return image.cloudflareImageID
+  }
+
+  fileprivate func userProfileResponse(
+    _ profile: UserProfile,
+    userID: UUID
+  ) async throws -> Components.Schemas.UserProfile {
+    let imageURL: String?
+    if let cloudflareImageID = profile.cloudflareImageID {
+      imageURL = try await profileImageURL(cloudflareImageID: cloudflareImageID, userID: userID)
+    } else {
+      imageURL = nil
+    }
+
+    return .init(profile, imageURL: imageURL)
+  }
+
+  fileprivate func cachedLatestProfile(userID: UUID) async throws -> UserProfile? {
+    let profileData = try await cache.getex(
+      latestUserProfileCacheKey(userID),
+      expiration: .seconds(60 * 10)
+    )
+    guard let profileData else { return nil }
+    return try JSONDecoder().decode(UserProfile.self, from: Data(profileData))
+  }
+
+  fileprivate func cacheLatestProfile(_ profile: UserProfile, userID: UUID) async throws {
+    try await cache.set(
+      latestUserProfileCacheKey(userID),
+      value: try JSONEncoder().encode(profile),
+      expiration: .seconds(60 * 10)
+    )
+  }
+
+  fileprivate func replaceCachedLatestProfile(_ profile: UserProfile, userID: UUID) async throws {
+    try await cache.del(keys: [latestUserProfileCacheKey(userID)])
+    try await cacheLatestProfile(profile, userID: userID)
+  }
+
+  fileprivate func profileImageURL(cloudflareImageID: String, userID: UUID) async throws -> String {
+    let key = imageURLCacheKey(userID: userID, cloudflareImageID: cloudflareImageID)
+    do {
+      if let imageURLData = try await cache.getex(key, expiration: .seconds(60 * 10)) {
+        return String(decoding: Data(imageURLData), as: UTF8.self)
+      }
+    } catch {
+      AppRequestContext.current?.logger.appLog(
+        level: .warning,
+        eventName: "image.url_cache_read_failed",
+        "Failed to fetch image URL from cache",
+        metadata: AppLogMetadata.userID(userID).merging([
+          "cache.operation": .string("getex"),
+          "image.id": .string(cloudflareImageID),
+        ]) { _, new in new },
+        error: error
+      )
+    }
+
+    let imageURL = try await cloudflareImagesClient.imageURL(
+      id: cloudflareImageID,
+      userID: userID
+    ).absoluteString
+    do {
+      try await cache.set(
+        key,
+        value: Data(imageURL.utf8),
+        expiration: .seconds(60 * 10)
+      )
+    } catch {
+      AppRequestContext.current?.logger.appLog(
+        level: .warning,
+        eventName: "image.url_cache_write_failed",
+        "Failed to write image URL to cache",
+        metadata: AppLogMetadata.userID(userID).merging([
+          "cache.operation": .string("set"),
+          "image.id": .string(cloudflareImageID),
+        ]) { _, new in new },
+        error: error
+      )
+    }
+    return imageURL
+  }
+
+  fileprivate func latestUserProfileCacheKey(_ userID: UUID) -> ValkeyKey {
+    ValkeyKey("user_profile:latest:\(userID.uuidString)")
+  }
+
+  fileprivate func imageURLCacheKey(userID: UUID, cloudflareImageID: String) -> ValkeyKey {
+    ValkeyKey("image_url:\(userID.uuidString):\(cloudflareImageID)")
   }
 }
 
 extension Components.Schemas.UserProfile {
-  init(_ profile: UserProfileRecord) {
+  fileprivate init(_ profile: UserProfile, imageURL: String?) {
     self.init(
       id: profile.id.uuidString,
-      userID: profile.userID.uuidString,
-      name: profile.name,
-      imageID: profile.imageID?.uuidString,
-      createdAt: profile.createdAt.timeIntervalSinceReferenceDate
+      userID: profile.userID!.uuidString,
+      name: profile.name!,
+      imageURL: imageURL,
+      createdAt: profile.createdAt!.timeIntervalSinceReferenceDate
     )
   }
 }

--- a/Sources/App/API/UserProfile.swift
+++ b/Sources/App/API/UserProfile.swift
@@ -5,8 +5,8 @@ import PostgresNIO
 import Records
 import SQLKit
 import StructuredQueriesPostgres
-import Valkey
 import UUIDV7
+import Valkey
 
 extension API {
   func getUserProfile(

--- a/Sources/App/API/UserProfileSelection.swift
+++ b/Sources/App/API/UserProfileSelection.swift
@@ -5,7 +5,6 @@ import Records
 struct UserProfile: Codable {
   var id: UUID
   var userID: UUID?
-  var email: String?
   var name: String?
   var cloudflareImageID: String?
   var createdAt: Date?
@@ -13,7 +12,6 @@ struct UserProfile: Codable {
   init(_ profile: UserProfileRecord, cloudflareImageID: String?) {
     self.id = profile.id
     self.userID = profile.userID
-    self.email = nil
     self.name = profile.name
     self.cloudflareImageID = cloudflareImageID
     self.createdAt = profile.createdAt

--- a/Sources/App/API/UserProfileSelection.swift
+++ b/Sources/App/API/UserProfileSelection.swift
@@ -1,0 +1,21 @@
+import Foundation
+import Records
+
+@Selection
+struct UserProfile: Codable {
+  var id: UUID
+  var userID: UUID?
+  var email: String?
+  var name: String?
+  var cloudflareImageID: String?
+  var createdAt: Date?
+
+  init(_ profile: UserProfileRecord, cloudflareImageID: String?) {
+    self.id = profile.id
+    self.userID = profile.userID
+    self.email = nil
+    self.name = profile.name
+    self.cloudflareImageID = cloudflareImageID
+    self.createdAt = profile.createdAt
+  }
+}

--- a/Sources/App/Model/UserEmail.swift
+++ b/Sources/App/Model/UserEmail.swift
@@ -5,4 +5,5 @@ import Records
 struct UserEmail: Codable, Hashable {
   @Column("user_id") var userID: UUID
   var email: String
+  @Column("created_at") var createdAt: Date
 }

--- a/Tests/AppTests/RouterTests.swift
+++ b/Tests/AppTests/RouterTests.swift
@@ -104,9 +104,9 @@ struct RouterTests {
         Components.Schemas.Me.self,
         from: getResponse.body
       )
-      #expect(getProfile.id == createdProfile.id)
       #expect(getProfile.userID == newUser.userID)
-      #expect(getProfile.name == "Alice")
+      #expect(getProfile.userProfile?.value1.name == "Alice")
+      #expect(getProfile.userProfile?.value1.createdAt == createdProfile.createdAt)
       #expect(getProfile.emails.isEmpty)
     }
   }
@@ -158,6 +158,23 @@ struct RouterTests {
         Components.Schemas.UserToken.self,
         from: newUserResponse.body
       )
+
+      let missingMeResponse = try await client.execute(
+        uri: "/me",
+        method: .get,
+        headers: [
+          .cfConnectingIP: ipAddress,
+          .authorization: "Bearer \(newUser.token)",
+        ]
+      )
+      #expect(missingMeResponse.status == .ok)
+      let missingMe = try JSONDecoder().decode(
+        Components.Schemas.Me.self,
+        from: missingMeResponse.body
+      )
+      #expect(missingMe.userID == newUser.userID)
+      #expect(missingMe.userProfile == nil)
+      #expect(missingMe.emails.isEmpty)
 
       let missingResponse = try await client.execute(
         uri: "/user_profile/\(newUser.userID)",
@@ -923,8 +940,9 @@ struct RouterTests {
           Components.Schemas.Me.self,
           from: getResponse.body
         )
-        #expect(getProfile.id == createdProfile.id)
         #expect(getProfile.userID == newUser.userID)
+        #expect(getProfile.userProfile?.value1.name == "Alice")
+        #expect(getProfile.userProfile?.value1.createdAt == createdProfile.createdAt)
         #expect(getProfile.emails.isEmpty)
       }
 

--- a/Tests/AppTests/RouterTests.swift
+++ b/Tests/AppTests/RouterTests.swift
@@ -74,7 +74,22 @@ struct RouterTests {
         Components.Schemas.UserToken.self,
         from: newUserResponse.body
       )
-      // 2. Get User to DB
+      let profileResponse = try await client.execute(
+        uri: "/me",
+        method: .post,
+        headers: [
+          .cfConnectingIP: ipAddress,
+          .authorization: "Bearer \(newUser.token)",
+        ],
+        body: ByteBuffer(data: JSONEncoder().encode(["name": "Alice"]))
+      )
+      #expect(profileResponse.status == .ok)
+      let createdProfile = try JSONDecoder().decode(
+        Components.Schemas.UserProfile.self,
+        from: profileResponse.body
+      )
+
+      // 2. Get latest user profile
       let getResponse = try await client.execute(
         uri: "/me",
         method: .get,
@@ -85,8 +100,13 @@ struct RouterTests {
       )
 
       #expect(getResponse.status == .ok)
-      let getUser = try JSONDecoder().decode(User.self, from: getResponse.body)
-      #expect(newUser.userID == getUser.id.uuidString)
+      let getProfile = try JSONDecoder().decode(
+        Components.Schemas.UserProfile.self,
+        from: getResponse.body
+      )
+      #expect(getProfile.id == createdProfile.id)
+      #expect(getProfile.userID == newUser.userID)
+      #expect(getProfile.name == "Alice")
     }
   }
 
@@ -98,7 +118,7 @@ struct RouterTests {
 
     try await app.test(.router) { client in
       let getResponse = try await client.execute(
-        uri: "/user_profile",
+        uri: "/user_profile/\(UUID().uuidString)",
         method: .get,
         headers: [
           .cfConnectingIP: ipAddress
@@ -107,7 +127,7 @@ struct RouterTests {
       #expect(getResponse.status == .unauthorized)
 
       let postResponse = try await client.execute(
-        uri: "/user_profile",
+        uri: "/me",
         method: .post,
         headers: [
           .cfConnectingIP: ipAddress
@@ -139,7 +159,7 @@ struct RouterTests {
       )
 
       let missingResponse = try await client.execute(
-        uri: "/user_profile",
+        uri: "/user_profile/\(newUser.userID)",
         method: .get,
         headers: [
           .cfConnectingIP: ipAddress,
@@ -149,7 +169,7 @@ struct RouterTests {
       #expect(missingResponse.status == .notFound)
 
       let firstProfile = try await client.execute(
-        uri: "/user_profile",
+        uri: "/me",
         method: .post,
         headers: [
           .cfConnectingIP: ipAddress,
@@ -162,10 +182,10 @@ struct RouterTests {
       }
       #expect(firstProfile.userID == newUser.userID)
       #expect(firstProfile.name == "Alice")
-      #expect(firstProfile.imageID == nil)
+      #expect(firstProfile.imageURL == nil)
 
       let secondProfile = try await client.execute(
-        uri: "/user_profile",
+        uri: "/me",
         method: .post,
         headers: [
           .cfConnectingIP: ipAddress,
@@ -178,10 +198,10 @@ struct RouterTests {
       }
       #expect(firstProfile.id != secondProfile.id)
       #expect(secondProfile.name == "Bob")
-      #expect(secondProfile.imageID == nil)
+      #expect(secondProfile.imageURL == nil)
 
       try await client.execute(
-        uri: "/user_profile",
+        uri: "/user_profile/\(newUser.userID)",
         method: .get,
         headers: [
           .cfConnectingIP: ipAddress,
@@ -195,7 +215,7 @@ struct RouterTests {
         )
         #expect(profile.id == secondProfile.id)
         #expect(profile.name == "Bob")
-        #expect(profile.imageID == nil)
+        #expect(profile.imageURL == nil)
       }
     }
   }
@@ -203,9 +223,10 @@ struct RouterTests {
   @Test
   func userProfileCanReferenceOwnImage() async throws {
     let arguments = TestArguments()
+    let recorder = TestCloudflareImagesCallRecorder()
     let app = try await buildApplication(
       arguments,
-      cloudflareImagesClient: TestCloudflareImagesClient()
+      cloudflareImagesClient: TestCloudflareImagesClient(recorder: recorder)
     )
     let ipAddress = UUID().uuidString
     let cloudflareImageID = UUID().uuidString
@@ -238,7 +259,7 @@ struct RouterTests {
       }
 
       let profile = try await client.execute(
-        uri: "/user_profile",
+        uri: "/me",
         method: .post,
         headers: [
           .cfConnectingIP: ipAddress,
@@ -254,10 +275,12 @@ struct RouterTests {
         #expect(response.status == .ok)
         return try JSONDecoder().decode(Components.Schemas.UserProfile.self, from: response.body)
       }
-      #expect(profile.imageID == image.id)
+      #expect(
+        profile.imageURL == "https://imagedelivery.net/account-hash/\(cloudflareImageID)/public")
+      #expect(await recorder.imageURLCount == 1)
 
       try await client.execute(
-        uri: "/user_profile",
+        uri: "/user_profile/\(newUser.userID)",
         method: .get,
         headers: [
           .cfConnectingIP: ipAddress,
@@ -270,8 +293,31 @@ struct RouterTests {
           from: response.body
         )
         #expect(latestProfile.id == profile.id)
-        #expect(latestProfile.imageID == image.id)
+        #expect(
+          latestProfile.imageURL
+            == "https://imagedelivery.net/account-hash/\(cloudflareImageID)/public")
       }
+      #expect(await recorder.imageURLCount == 1)
+
+      try await client.execute(
+        uri: "/user_profile/\(newUser.userID)",
+        method: .get,
+        headers: [
+          .cfConnectingIP: ipAddress,
+          .authorization: "Bearer \(newUser.token)",
+        ]
+      ) { response in
+        #expect(response.status == .ok)
+        let latestProfile = try JSONDecoder().decode(
+          Components.Schemas.UserProfile.self,
+          from: response.body
+        )
+        #expect(latestProfile.id == profile.id)
+        #expect(
+          latestProfile.imageURL
+            == "https://imagedelivery.net/account-hash/\(cloudflareImageID)/public")
+      }
+      #expect(await recorder.imageURLCount == 1)
     }
   }
 
@@ -321,7 +367,7 @@ struct RouterTests {
       }
 
       let response = try await client.execute(
-        uri: "/user_profile",
+        uri: "/me",
         method: .post,
         headers: [
           .cfConnectingIP: ipAddress,
@@ -360,7 +406,7 @@ struct RouterTests {
 
       for invalidName in ["", "   ", String(repeating: "a", count: 101)] {
         let response = try await client.execute(
-          uri: "/user_profile",
+          uri: "/me",
           method: .post,
           headers: [
             .cfConnectingIP: ipAddress,
@@ -454,11 +500,13 @@ struct RouterTests {
   @Test
   func createImageRegistersUploadedImageIdempotently() async throws {
     let arguments = TestArguments()
+    let recorder = TestCloudflareImagesCallRecorder()
     let app = try await buildApplication(
       arguments,
-      cloudflareImagesClient: TestCloudflareImagesClient()
+      cloudflareImagesClient: TestCloudflareImagesClient(recorder: recorder)
     )
     let ipAddress = UUID().uuidString
+    let cloudflareImageID = UUID().uuidString
 
     try await app.test(.router) { client in
       let newUserResponse = try await client.execute(
@@ -481,12 +529,12 @@ struct RouterTests {
           .cfConnectingIP: ipAddress,
           .authorization: "Bearer \(newUser.token)",
         ],
-        body: ByteBuffer(data: JSONEncoder().encode(["imageID": "cloudflare-image-id"]))
+        body: ByteBuffer(data: JSONEncoder().encode(["imageID": cloudflareImageID]))
       ) { response in
         #expect(response.status == .ok)
         return try JSONDecoder().decode(Components.Schemas.Image.self, from: response.body)
       }
-      #expect(firstImage.imageID == "cloudflare-image-id")
+      #expect(firstImage.imageID == cloudflareImageID)
 
       let secondImage = try await client.execute(
         uri: "/images",
@@ -495,13 +543,14 @@ struct RouterTests {
           .cfConnectingIP: ipAddress,
           .authorization: "Bearer \(newUser.token)",
         ],
-        body: ByteBuffer(data: JSONEncoder().encode(["imageID": "cloudflare-image-id"]))
+        body: ByteBuffer(data: JSONEncoder().encode(["imageID": cloudflareImageID]))
       ) { response in
         #expect(response.status == .ok)
         return try JSONDecoder().decode(Components.Schemas.Image.self, from: response.body)
       }
       #expect(secondImage.id == firstImage.id)
       #expect(secondImage.imageID == firstImage.imageID)
+      #expect(await recorder.verifyUploadedImageCount == 1)
     }
   }
 
@@ -842,8 +891,23 @@ struct RouterTests {
         Components.Schemas.UserToken.self,
         from: newUserResponse.body
       )
+      let profileResponse = try await client.execute(
+        uri: "/me",
+        method: .post,
+        headers: [
+          .authorization: "Bearer \(newUser.token)",
+          .cfConnectingIP: ipAddress,
+        ],
+        body: ByteBuffer(data: JSONEncoder().encode(["name": "Alice"]))
+      )
+      #expect(profileResponse.status == .ok)
+      let createdProfile = try JSONDecoder().decode(
+        Components.Schemas.UserProfile.self,
+        from: profileResponse.body
+      )
+
       for _ in 0..<arguments.rateLimitUserTokenMaxCount! {
-        // 2. Get User to DB
+        // 2. Get latest user profile
         let getResponse = try await client.execute(
           uri: "/me",
           method: .get,
@@ -854,8 +918,12 @@ struct RouterTests {
         )
 
         #expect(getResponse.status == .ok)
-        let getUser = try JSONDecoder().decode(User.self, from: getResponse.body)
-        #expect(newUser.userID == getUser.id.uuidString)
+        let getProfile = try JSONDecoder().decode(
+          Components.Schemas.UserProfile.self,
+          from: getResponse.body
+        )
+        #expect(getProfile.id == createdProfile.id)
+        #expect(getProfile.userID == newUser.userID)
       }
 
       let getResponse = try await client.execute(
@@ -909,8 +977,11 @@ private struct TestCloudflareImagesClient: CloudflareImagesClientProtocol {
   )
   var directUploadError: TestCloudflareImagesError?
   var verifyError: TestCloudflareImagesError?
+  var imageURLError: TestCloudflareImagesError?
+  var recorder: TestCloudflareImagesCallRecorder?
 
   func createDirectUploadURL(userID: UUID) async throws -> CloudflareDirectUpload {
+    await recorder?.recordCreateDirectUploadURL()
     if let directUploadError {
       throw directUploadError
     }
@@ -918,9 +989,36 @@ private struct TestCloudflareImagesClient: CloudflareImagesClientProtocol {
   }
 
   func verifyUploadedImage(id: String, userID: UUID) async throws {
+    await recorder?.recordVerifyUploadedImage()
     if let verifyError {
       throw verifyError
     }
+  }
+
+  func imageURL(id: String, userID: UUID) async throws -> URL {
+    await recorder?.recordImageURL()
+    if let imageURLError {
+      throw imageURLError
+    }
+    return URL(string: "https://imagedelivery.net/account-hash/\(id)/public")!
+  }
+}
+
+private actor TestCloudflareImagesCallRecorder {
+  private(set) var createDirectUploadURLCount = 0
+  private(set) var verifyUploadedImageCount = 0
+  private(set) var imageURLCount = 0
+
+  func recordCreateDirectUploadURL() {
+    createDirectUploadURLCount += 1
+  }
+
+  func recordVerifyUploadedImage() {
+    verifyUploadedImageCount += 1
+  }
+
+  func recordImageURL() {
+    imageURLCount += 1
   }
 }
 

--- a/Tests/AppTests/RouterTests.swift
+++ b/Tests/AppTests/RouterTests.swift
@@ -101,12 +101,13 @@ struct RouterTests {
 
       #expect(getResponse.status == .ok)
       let getProfile = try JSONDecoder().decode(
-        Components.Schemas.UserProfile.self,
+        Components.Schemas.Me.self,
         from: getResponse.body
       )
       #expect(getProfile.id == createdProfile.id)
       #expect(getProfile.userID == newUser.userID)
       #expect(getProfile.name == "Alice")
+      #expect(getProfile.emails.isEmpty)
     }
   }
 
@@ -906,7 +907,7 @@ struct RouterTests {
         from: profileResponse.body
       )
 
-      for _ in 0..<arguments.rateLimitUserTokenMaxCount! {
+      for _ in 0..<(arguments.rateLimitUserTokenMaxCount! - 1) {
         // 2. Get latest user profile
         let getResponse = try await client.execute(
           uri: "/me",
@@ -919,11 +920,12 @@ struct RouterTests {
 
         #expect(getResponse.status == .ok)
         let getProfile = try JSONDecoder().decode(
-          Components.Schemas.UserProfile.self,
+          Components.Schemas.Me.self,
           from: getResponse.body
         )
         #expect(getProfile.id == createdProfile.id)
         #expect(getProfile.userID == newUser.userID)
+        #expect(getProfile.emails.isEmpty)
       }
 
       let getResponse = try await client.execute(

--- a/public/documents/openapi.yml
+++ b/public/documents/openapi.yml
@@ -171,24 +171,6 @@ paths:
         - bearerAuth: []
       responses:
         '200':
-          description: A success response with a user.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/User'
-        '400':
-          description: A bad request
-        '401':
-          description: Not Authorization
-        '404':
-          description: Not found User
-  /user_profile:
-    get:
-      operationId: getUserProfile
-      security:
-        - bearerAuth: []
-      responses:
-        '200':
           description: A success response with the latest user profile.
           content:
             application/json:
@@ -221,6 +203,32 @@ paths:
           description: A bad request
         '401':
           description: Not Authorization
+  /user_profile/{user_id}:
+    get:
+      operationId: getUserProfile
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: user_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: User id.
+      responses:
+        '200':
+          description: A success response with the latest user profile.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserProfile'
+        '400':
+          description: A bad request
+        '401':
+          description: Not Authorization
+        '404':
+          description: Not found User Profile
   /images/upload_url:
     post:
       operationId: createImageUploadURL
@@ -394,10 +402,10 @@ components:
         name:
           type: string
           description: User profile name.
-        imageID:
+        imageURL:
           type: string
-          format: uuid
-          description: Image id for the profile image.
+          format: uri
+          description: Image URL for the profile image.
         createdAt:
           type: number
           format: double

--- a/public/documents/openapi.yml
+++ b/public/documents/openapi.yml
@@ -171,7 +171,7 @@ paths:
         - bearerAuth: []
       responses:
         '200':
-          description: A success response with the latest user profile.
+          description: A success response with the current user state.
           content:
             application/json:
               schema:
@@ -180,8 +180,6 @@ paths:
           description: A bad request
         '401':
           description: Not Authorization
-        '404':
-          description: Not found User Profile
     post:
       operationId: createUserProfile
       security:
@@ -419,14 +417,27 @@ components:
       type: object
       description: A value with the current user profile and registered email addresses.
       properties:
-        id:
-          type: string
-          format: uuid
-          description: User profile id.
         userID:
           type: string
           format: uuid
           description: User id.
+        userProfile:
+          allOf:
+            - $ref: '#/components/schemas/MeUserProfile'
+          nullable: true
+          description: Current user profile, or null when it is not created yet.
+        emails:
+          type: array
+          description: Registered email addresses.
+          items:
+            $ref: '#/components/schemas/Email'
+      required:
+        - userID
+        - emails
+    MeUserProfile:
+      type: object
+      description: A current user profile summary for the authenticated user.
+      properties:
         name:
           type: string
           description: User profile name.
@@ -438,17 +449,9 @@ components:
           type: number
           format: double
           description: User profile created date.
-        emails:
-          type: array
-          description: Registered email addresses.
-          items:
-            $ref: '#/components/schemas/Email'
       required:
-        - id
-        - userID
         - name
         - createdAt
-        - emails
     Email:
       type: object
       description: A registered email address.

--- a/public/documents/openapi.yml
+++ b/public/documents/openapi.yml
@@ -175,7 +175,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UserProfile'
+                $ref: '#/components/schemas/Me'
         '400':
           description: A bad request
         '401':
@@ -414,6 +414,55 @@ components:
         - id
         - userID
         - name
+        - createdAt
+    Me:
+      type: object
+      description: A value with the current user profile and registered email addresses.
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: User profile id.
+        userID:
+          type: string
+          format: uuid
+          description: User id.
+        name:
+          type: string
+          description: User profile name.
+        imageURL:
+          type: string
+          format: uri
+          description: Image URL for the profile image.
+        createdAt:
+          type: number
+          format: double
+          description: User profile created date.
+        emails:
+          type: array
+          description: Registered email addresses.
+          items:
+            $ref: '#/components/schemas/Email'
+      required:
+        - id
+        - userID
+        - name
+        - createdAt
+        - emails
+    Email:
+      type: object
+      description: A registered email address.
+      properties:
+        email:
+          type: string
+          format: email
+          description: Registered email address.
+        createdAt:
+          type: number
+          format: double
+          description: Registered email created date.
+      required:
+        - email
         - createdAt
     CreateUserProfileRequest:
       type: object

--- a/public/documents/openapi.yml
+++ b/public/documents/openapi.yml
@@ -401,7 +401,9 @@ components:
           type: string
           description: User profile name.
         imageURL:
-          type: string
+          type:
+            - string
+            - 'null'
           format: uri
           description: Image URL for the profile image.
         createdAt:
@@ -442,7 +444,9 @@ components:
           type: string
           description: User profile name.
         imageURL:
-          type: string
+          type:
+            - string
+            - 'null'
           format: uri
           description: Image URL for the profile image.
         createdAt:

--- a/public/index.html
+++ b/public/index.html
@@ -88,6 +88,17 @@
       margin: 0.35rem 0 0;
       font-size: 0.95rem;
     }
+    .email-list {
+      margin: 1rem 0 0;
+      padding-left: 1.25rem;
+    }
+    .email-list:empty {
+      display: none;
+    }
+    .email-list li {
+      margin: 0.25rem 0;
+      word-break: break-all;
+    }
     .field {
       margin-bottom: 0.9rem;
     }
@@ -148,6 +159,14 @@
       </div>
       <button id="confirm-email" type="button">コードを送信</button>
       <p id="email-confirm-status" class="status" role="status"></p>
+    </section>
+
+    <section>
+      <h2>登録メールアドレス</h2>
+      <p>現在のトークンに紐づく登録済みメールアドレスを取得します。</p>
+      <button id="load-emails" type="button">メールアドレス取得</button>
+      <p id="emails-status" class="status" role="status"></p>
+      <ul id="emails-list" class="email-list"></ul>
     </section>
 
     <section>
@@ -236,6 +255,13 @@
         session,
         status,
         inputs: elements.inputs,
+        emailsList: elements.emailsList,
+      });
+      const emailsFlow = createEmailsFlow({
+        api,
+        session,
+        status,
+        emailsList: elements.emailsList,
       });
       const emailLoginFlow = createEmailLoginFlow({
         api,
@@ -268,6 +294,7 @@
           create,
           sendEmail,
           confirmEmail,
+          loadEmails,
           addPasskey,
           login,
           startEmailLogin,
@@ -279,6 +306,7 @@
         bindAsync(create, userFlow);
         bindAsync(sendEmail, emailVerificationFlow.send);
         bindAsync(confirmEmail, emailVerificationFlow.confirm);
+        bindAsync(loadEmails, emailsFlow);
         bindAsync(addPasskey, passkeyFlow.add);
         bindAsync(login, passkeyFlow.login);
         bindAsync(startEmailLogin, emailLoginFlow.start);
@@ -300,11 +328,12 @@
       function createUserFlow({ api, session, status, state }) {
         return async function handleCreateUser() {
           status.set('create', 'ユーザー作成中...');
-          status.clear('emailStart', 'emailConfirm', 'passkey', 'login', 'emailLogin', 'logout');
+          status.clear('emailStart', 'emailConfirm', 'emails', 'passkey', 'login', 'emailLogin', 'logout');
           try {
             const payload = await api.createUser();
             session.apply(payload);
-            session.updateEmail(null);
+            session.updateEmails([]);
+            renderEmailsList(elements.emailsList, []);
             state.emailLoginChallenge = null;
             status.set('create', 'ユーザーを作成しトークンを取得しました。');
           } catch (error) {
@@ -314,7 +343,7 @@
         };
       }
 
-      function createEmailVerificationFlow({ api, session, status, inputs }) {
+      function createEmailVerificationFlow({ api, session, status, inputs, emailsList }) {
         const emailInput = inputs.email;
         const codeInput = inputs.code;
 
@@ -333,7 +362,6 @@
             status.clear('emailConfirm', 'logout');
             try {
               await api.sendVerificationEmail({ email, token });
-              session.updateEmail(email);
               status.set('emailStart', '確認メールを送信しました。');
             } catch (error) {
               console.error(error);
@@ -357,7 +385,9 @@
             status.clear('logout');
             try {
               await api.confirmEmailAddress({ email, code, token });
-              session.updateEmail(email);
+              const emails = await api.fetchEmailsFromMe(token);
+              session.updateEmails(emails);
+              renderEmailsList(emailsList, emails);
               codeInput.value = '';
               status.set('emailConfirm', 'メールアドレスを認証しました。');
             } catch (error) {
@@ -415,7 +445,7 @@
               });
               state.emailLoginChallenge = null;
               session.apply(tokens);
-              session.updateEmail(email);
+              await refreshSessionEmails(tokens.token);
               codeInput.value = '';
               status.set('emailLogin', 'メールアドレスでログインしました。');
               status.clear('login');
@@ -446,7 +476,7 @@
               const options = webAuthn.buildRegistrationOptions({
                 challenge,
                 userID,
-                email: session.data.email,
+                email: session.data.emails[0]?.email,
               });
               const credential = await navigator.credentials.create({ publicKey: options });
               if (!credential) {
@@ -482,7 +512,7 @@
               const payload = webAuthn.serializeAuthenticationCredential(credential, challenge);
               const tokens = await api.requestPasskeyToken(payload);
               session.apply(tokens);
-              await refreshSessionEmail(tokens.token);
+              await refreshSessionEmails(tokens.token);
               status.set('login', 'Passkeyでログインしました。新しいトークンを取得しました。');
             } catch (error) {
               console.error(error);
@@ -593,20 +623,59 @@
           session.reset();
           state.emailLoginChallenge = null;
           profileImageFlow.resetDisplay();
+          renderEmailsList(elements.emailsList, []);
           status.set('logout', 'ログアウトしました。');
-          status.clear('create', 'emailStart', 'emailConfirm', 'passkey', 'login', 'emailLogin', 'profileImage');
+          status.clear('create', 'emailStart', 'emailConfirm', 'emails', 'passkey', 'login', 'emailLogin', 'profileImage');
         };
       }
 
-      async function refreshSessionEmail(token) {
+      function createEmailsFlow({ api, session, status, emailsList }) {
+        return async function handleLoadEmails() {
+          const { token } = session.data;
+          if (!validate('emails', [
+            { predicate: () => !!token, message: '先にユーザーを作成またはログインしてください。' },
+          ])) {
+            return;
+          }
+
+          status.set('emails', 'メールアドレス取得中...');
+          status.clear('logout');
+          try {
+            const emails = await api.fetchEmailsFromMe(token);
+            session.updateEmails(emails);
+            renderEmailsList(emailsList, emails);
+            status.set('emails', emails.length > 0 ? 'メールアドレスを取得しました。' : '登録済みメールアドレスはありません。');
+          } catch (error) {
+            console.error(error);
+            status.set('emails', error.message || 'メールアドレスの取得に失敗しました。', { error: true });
+          }
+        };
+      }
+
+      async function refreshSessionEmails(token) {
         if (!token) {
           return;
         }
         try {
-          const user = await api.fetchCurrentUser(token);
-          session.updateEmail(user?.email ?? null);
+          const emails = await api.fetchEmailsFromMe(token);
+          session.updateEmails(emails);
+          renderEmailsList(elements.emailsList, emails);
         } catch (error) {
           console.error(error);
+        }
+      }
+
+      function renderEmailsList(list, emails) {
+        list.replaceChildren();
+        for (const item of emails) {
+          const email = (typeof item === 'string' ? item : item?.email)?.trim();
+          if (!email) continue;
+          const createdAt = typeof item?.createdAt === 'number'
+            ? ` (${formatReferenceDate(item.createdAt)})`
+            : '';
+          const listItem = document.createElement('li');
+          listItem.textContent = `${email}${createdAt}`;
+          list.appendChild(listItem);
         }
       }
 
@@ -639,6 +708,7 @@
             create: document.getElementById('create-user'),
             sendEmail: document.getElementById('send-email'),
             confirmEmail: document.getElementById('confirm-email'),
+            loadEmails: document.getElementById('load-emails'),
             addPasskey: document.getElementById('add-passkey'),
             login: document.getElementById('login'),
             startEmailLogin: document.getElementById('start-email-login'),
@@ -650,6 +720,7 @@
             create: document.getElementById('create-status'),
             emailStart: document.getElementById('email-start-status'),
             emailConfirm: document.getElementById('email-confirm-status'),
+            emails: document.getElementById('emails-status'),
             passkey: document.getElementById('passkey-status'),
             login: document.getElementById('login-status'),
             emailLogin: document.getElementById('email-login-status'),
@@ -671,6 +742,7 @@
             name: document.getElementById('current-profile-name'),
             imageURL: document.getElementById('current-profile-image-url'),
           },
+          emailsList: document.getElementById('emails-list'),
           sessionOutput: document.getElementById('session-output'),
         };
       }
@@ -696,14 +768,13 @@
       }
 
       function createSessionManager(outputElement) {
-        const APPLE_REFERENCE_DATE_MS = Date.UTC(2001, 0, 1);
         const data = {
           userID: null,
           token: null,
           tokenExpiresAt: null,
           refreshToken: null,
           refreshTokenExpiresAt: null,
-          email: null,
+          emails: [],
           profile: null,
         };
 
@@ -733,8 +804,8 @@
             data.refreshTokenExpiresAt = formatReferenceDate(payload?.refreshTokenExpiredDate);
             render();
           },
-          updateEmail(email) {
-            data.email = email ? email.trim() : null;
+          updateEmails(emails) {
+            data.emails = Array.isArray(emails) ? emails : [];
             render();
           },
           updateProfile(profile) {
@@ -747,13 +818,22 @@
             data.tokenExpiresAt = null;
             data.refreshToken = null;
             data.refreshTokenExpiresAt = null;
-            data.email = null;
+            data.emails = [];
             data.profile = null;
             render();
           },
           render,
         };
       }
+
+      function formatReferenceDate(value) {
+        if (typeof value !== 'number' || Number.isNaN(value)) {
+          return null;
+        }
+        return new Date(APPLE_REFERENCE_DATE_MS + value * 1000).toISOString();
+      }
+
+      const APPLE_REFERENCE_DATE_MS = Date.UTC(2001, 0, 1);
 
       function createApi() {
         return {
@@ -813,6 +893,15 @@
               message: 'ユーザー情報の取得に失敗しました。',
             });
             return response.json();
+          },
+
+          async fetchEmailsFromMe(token) {
+            const response = await get('/me', {
+              headers: { Authorization: `Bearer ${token}` },
+              message: 'メールアドレスの取得に失敗しました。',
+            });
+            const me = await response.json();
+            return Array.isArray(me?.emails) ? me.emails : [];
           },
 
           async sendEmailLoginChallenge(email) {

--- a/public/index.html
+++ b/public/index.html
@@ -69,6 +69,25 @@
       border-color: #60a5fa;
       box-shadow: 0 0 0 3px rgba(96, 165, 250, 0.25);
     }
+    img {
+      display: block;
+      max-width: 160px;
+      max-height: 160px;
+      border-radius: 12px;
+      object-fit: cover;
+    }
+    img[hidden] {
+      display: none;
+    }
+    .profile-result {
+      margin-top: 1rem;
+      padding-top: 1rem;
+      border-top: 1px solid #e2e8f0;
+    }
+    .profile-result p {
+      margin: 0.35rem 0 0;
+      font-size: 0.95rem;
+    }
     .field {
       margin-bottom: 0.9rem;
     }
@@ -162,6 +181,29 @@
     </section>
 
     <section>
+      <h2>プロフィール画像</h2>
+      <p>画像をアップロードし、プロフィール名と一緒に最新プロフィールへ登録します。</p>
+      <div class="field">
+        <label for="profile-name-input">プロフィール名</label>
+        <input id="profile-name-input" type="text" autocomplete="name" maxlength="100" placeholder="表示名">
+      </div>
+      <div class="field">
+        <label for="profile-image-file">画像ファイル</label>
+        <input id="profile-image-file" type="file" accept="image/*">
+      </div>
+      <div class="field">
+        <img id="profile-image-preview" alt="選択したプロフィール画像のプレビュー" hidden>
+      </div>
+      <button id="upload-profile-image" type="button">画像を登録</button>
+      <p id="profile-image-status" class="status" role="status"></p>
+      <div id="current-profile" class="profile-result" hidden>
+        <img id="current-profile-image" alt="プロフィールに設定した画像">
+        <p id="current-profile-name"></p>
+        <p id="current-profile-image-url"></p>
+      </div>
+    </section>
+
+    <section>
       <h2>ログアウト</h2>
       <p>保持しているセッション情報を破棄します。</p>
       <button id="logout" type="button">ログアウト</button>
@@ -209,7 +251,15 @@
         webAuthn,
         supportsWebAuthn,
       });
-      const logoutFlow = createLogoutFlow({ session, status, state });
+      const profileImageFlow = createProfileImageFlow({
+        api,
+        session,
+        status,
+        inputs: elements.inputs,
+        preview: elements.profileImagePreview,
+        currentProfile: elements.currentProfile,
+      });
+      const logoutFlow = createLogoutFlow({ session, status, state, profileImageFlow });
 
       init();
 
@@ -222,6 +272,7 @@
           login,
           startEmailLogin,
           completeEmailLogin,
+          uploadProfileImage,
           logout,
         } = elements.buttons;
 
@@ -232,6 +283,8 @@
         bindAsync(login, passkeyFlow.login);
         bindAsync(startEmailLogin, emailLoginFlow.start);
         bindAsync(completeEmailLogin, emailLoginFlow.complete);
+        bindAsync(uploadProfileImage, profileImageFlow.uploadAndRegister);
+        elements.inputs.profileImageFile.addEventListener('change', profileImageFlow.previewSelectedFile);
         logout.addEventListener('click', logoutFlow);
 
         if (!supportsWebAuthn) {
@@ -439,12 +492,109 @@
         };
       }
 
-      function createLogoutFlow({ session, status, state }) {
+      function createProfileImageFlow({ api, session, status, inputs, preview, currentProfile }) {
+        let previewURL = null;
+        let currentImageURL = null;
+
+        function setPreview(file) {
+          if (previewURL) {
+            URL.revokeObjectURL(previewURL);
+            previewURL = null;
+          }
+          if (!file) {
+            preview.hidden = true;
+            preview.removeAttribute('src');
+            return;
+          }
+          previewURL = URL.createObjectURL(file);
+          preview.src = previewURL;
+          preview.hidden = false;
+        }
+
+        function setCurrentProfile({ profile, file }) {
+          if (currentImageURL) {
+            URL.revokeObjectURL(currentImageURL);
+          }
+          currentImageURL = URL.createObjectURL(file);
+          currentProfile.image.src = profile.imageURL || currentImageURL;
+          currentProfile.name.textContent = `名前: ${profile.name}`;
+          currentProfile.imageURL.textContent = `画像URL: ${profile.imageURL || ''}`;
+          currentProfile.container.hidden = false;
+        }
+
+        function resetDisplay() {
+          if (previewURL) {
+            URL.revokeObjectURL(previewURL);
+            previewURL = null;
+          }
+          if (currentImageURL) {
+            URL.revokeObjectURL(currentImageURL);
+            currentImageURL = null;
+          }
+          preview.hidden = true;
+          preview.removeAttribute('src');
+          currentProfile.image.removeAttribute('src');
+          currentProfile.name.textContent = '';
+          currentProfile.imageURL.textContent = '';
+          currentProfile.container.hidden = true;
+        }
+
+        return {
+          previewSelectedFile() {
+            setPreview(inputs.profileImageFile.files?.[0] ?? null);
+          },
+
+          resetDisplay,
+
+          async uploadAndRegister() {
+            const { token } = session.data;
+            const name = inputs.profileName.value.trim();
+            const file = inputs.profileImageFile.files?.[0] ?? null;
+
+            if (!validate('profileImage', [
+              { predicate: () => !!token, message: '先にユーザーを作成またはログインしてください。' },
+              { predicate: () => name.length > 0, message: 'プロフィール名を入力してください。' },
+              { predicate: () => name.length <= 100, message: 'プロフィール名は100文字以内で入力してください。' },
+              { predicate: () => !!file, message: '画像ファイルを選択してください。' },
+            ])) {
+              return;
+            }
+
+            status.set('profileImage', 'アップロードURL取得中...');
+            status.clear('logout');
+            try {
+              const upload = await api.createImageUploadURL(token);
+              status.set('profileImage', '画像アップロード中...');
+              await api.uploadImageFile({ uploadURL: upload.uploadURL, file });
+
+              status.set('profileImage', '画像登録中...');
+              const image = await api.createImage({ imageID: upload.imageID, token });
+
+              status.set('profileImage', 'プロフィール登録中...');
+              const profile = await api.createUserProfile({
+                name,
+                imageID: image.id,
+                token,
+              });
+
+              session.updateProfile(profile);
+              setCurrentProfile({ profile, file });
+              status.set('profileImage', 'プロフィール画像を登録しました。');
+            } catch (error) {
+              console.error(error);
+              status.set('profileImage', error.message || 'プロフィール画像の登録に失敗しました。', { error: true });
+            }
+          },
+        };
+      }
+
+      function createLogoutFlow({ session, status, state, profileImageFlow }) {
         return function handleLogout() {
           session.reset();
           state.emailLoginChallenge = null;
+          profileImageFlow.resetDisplay();
           status.set('logout', 'ログアウトしました。');
-          status.clear('create', 'emailStart', 'emailConfirm', 'passkey', 'login', 'emailLogin');
+          status.clear('create', 'emailStart', 'emailConfirm', 'passkey', 'login', 'emailLogin', 'profileImage');
         };
       }
 
@@ -493,6 +643,7 @@
             login: document.getElementById('login'),
             startEmailLogin: document.getElementById('start-email-login'),
             completeEmailLogin: document.getElementById('complete-email-login'),
+            uploadProfileImage: document.getElementById('upload-profile-image'),
             logout: document.getElementById('logout'),
           },
           statuses: {
@@ -502,6 +653,7 @@
             passkey: document.getElementById('passkey-status'),
             login: document.getElementById('login-status'),
             emailLogin: document.getElementById('email-login-status'),
+            profileImage: document.getElementById('profile-image-status'),
             logout: document.getElementById('logout-status'),
           },
           inputs: {
@@ -509,6 +661,15 @@
             code: document.getElementById('email-code'),
             emailLoginEmail: document.getElementById('email-login-input'),
             emailLoginCode: document.getElementById('email-login-code'),
+            profileName: document.getElementById('profile-name-input'),
+            profileImageFile: document.getElementById('profile-image-file'),
+          },
+          profileImagePreview: document.getElementById('profile-image-preview'),
+          currentProfile: {
+            container: document.getElementById('current-profile'),
+            image: document.getElementById('current-profile-image'),
+            name: document.getElementById('current-profile-name'),
+            imageURL: document.getElementById('current-profile-image-url'),
           },
           sessionOutput: document.getElementById('session-output'),
         };
@@ -543,6 +704,7 @@
           refreshToken: null,
           refreshTokenExpiresAt: null,
           email: null,
+          profile: null,
         };
 
         function render() {
@@ -575,6 +737,10 @@
             data.email = email ? email.trim() : null;
             render();
           },
+          updateProfile(profile) {
+            data.profile = profile ?? null;
+            render();
+          },
           reset() {
             data.userID = null;
             data.token = null;
@@ -582,6 +748,7 @@
             data.refreshToken = null;
             data.refreshTokenExpiresAt = null;
             data.email = null;
+            data.profile = null;
             render();
           },
           render,
@@ -660,6 +827,37 @@
           async exchangeEmailCodeForToken(payload) {
             return postJSON('/token/email', payload, {
               message: 'メールでのログインに失敗しました。',
+            });
+          },
+
+          async createImageUploadURL(token) {
+            const response = await post('/images/upload_url', {
+              headers: { Authorization: `Bearer ${token}` },
+              message: '画像アップロードURLの取得に失敗しました。',
+            });
+            return response.json();
+          },
+
+          async uploadImageFile({ uploadURL, file }) {
+            const body = new FormData();
+            body.append('file', file);
+            await post(uploadURL, {
+              body,
+              message: '画像アップロードに失敗しました。',
+            });
+          },
+
+          async createImage({ imageID, token }) {
+            return postJSON('/images', { imageID }, {
+              headers: { Authorization: `Bearer ${token}` },
+              message: '画像登録に失敗しました。',
+            });
+          },
+
+          async createUserProfile({ name, imageID, token }) {
+            return postJSON('/me', { name, imageID }, {
+              headers: { Authorization: `Bearer ${token}` },
+              message: 'プロフィール登録に失敗しました。',
             });
           },
         };


### PR DESCRIPTION
## Summary

- Return a Cloudflare Images delivery URL from profile responses instead of exposing only the image id.
- Update `GET /me` to return authenticated user state as `userID`, nullable `userProfile`, and registered `emails`.
- Keep `GET /user_profile/{user_id}` as the profile-only API and return `404` when the target profile has not been created.
- Cache user profiles, image records, and image URLs in Valkey with the existing 10 minute TTL.
- Update OpenAPI so nullable primitive `imageURL` fields use OpenAPI 3.1 `type: [string, "null"]`.

## API changes

### `GET /me`

Returns `200` even when the profile is not created yet:

```json
{
  "userID": "...",
  "userProfile": null,
  "emails": [
    {
      "email": "user@example.com",
      "createdAt": 1234567890.0
    }
  ]
}
```

When a profile exists, `userProfile` contains:

```json
{
  "name": "Alice",
  "imageURL": "https://imagedelivery.net/...",
  "createdAt": 1234567890.0
}
```

### `GET /user_profile/{user_id}`

- Returns the latest profile for the specified user.
- Includes image URL data when the profile has an image.
- Still returns `404` when the profile has not been created.

### `POST /me`

- Keeps the append-only profile creation behavior.
- Supports profile image registration through the existing image id flow.
- Refreshes latest-profile cache after insert.

## Cache behavior

- `user_profile:latest:{userID}` caches the latest profile selection.
- `image:id:{imageUUID}` caches image rows by local image id.
- `image:cloudflare_id:{cloudflareImageID}` caches image rows by Cloudflare image id.
- `image_url:{userID}:{cloudflareImageID}` caches Cloudflare delivery URLs.
- Profile creation deletes the old latest-profile cache and stores the new profile.