### PR TITLE
Fix OpenAPI 3.1 nullable schema for /me response

### DIFF
--- a/Sources/App/API/GetMe.swift
+++ b/Sources/App/API/GetMe.swift
@@ -59,7 +59,7 @@ extension Components.Schemas.Me {
   fileprivate init(userID: UUID, profile: Components.Schemas.UserProfile?, emails: [UserEmail]) {
     self.init(
       userID: userID.uuidString,
-      userProfile: profile.map { .init(value1: .init($0)) },
+      userProfile: profile.map { .init($0) },
       emails: emails.map { .init($0) }
     )
   }

--- a/Tests/AppTests/RouterTests.swift
+++ b/Tests/AppTests/RouterTests.swift
@@ -105,8 +105,8 @@ struct RouterTests {
         from: getResponse.body
       )
       #expect(getProfile.userID == newUser.userID)
-      #expect(getProfile.userProfile?.value1.name == "Alice")
-      #expect(getProfile.userProfile?.value1.createdAt == createdProfile.createdAt)
+      #expect(getProfile.userProfile?.name == "Alice")
+      #expect(getProfile.userProfile?.createdAt == createdProfile.createdAt)
       #expect(getProfile.emails.isEmpty)
     }
   }
@@ -941,8 +941,8 @@ struct RouterTests {
           from: getResponse.body
         )
         #expect(getProfile.userID == newUser.userID)
-        #expect(getProfile.userProfile?.value1.name == "Alice")
-        #expect(getProfile.userProfile?.value1.createdAt == createdProfile.createdAt)
+        #expect(getProfile.userProfile?.name == "Alice")
+        #expect(getProfile.userProfile?.createdAt == createdProfile.createdAt)
         #expect(getProfile.emails.isEmpty)
       }
 

--- a/public/documents/openapi.yml
+++ b/public/documents/openapi.yml
@@ -424,9 +424,7 @@ components:
           format: uuid
           description: User id.
         userProfile:
-          allOf:
-            - $ref: '#/components/schemas/MeUserProfile'
-          nullable: true
+          $ref: '#/components/schemas/MeUserProfile'
           description: Current user profile, or null when it is not created yet.
         emails:
           type: array
@@ -435,9 +433,12 @@ components:
             $ref: '#/components/schemas/Email'
       required:
         - userID
+        - userProfile
         - emails
     MeUserProfile:
-      type: object
+      type:
+        - object
+        - 'null'
       description: A current user profile summary for the authenticated user.
       properties:
         name:


### PR DESCRIPTION
## Summary
- Replace the OpenAPI 3.0-style `nullable: true` usage in the `/me` response schema with an OpenAPI 3.1-compatible nullable component schema.
- Keep `userProfile` present in the `Me` response shape while allowing its value to be `null`.
- Update `GetMe` response construction to match the generated `MeUserProfile?` type instead of the previous `anyOf` wrapper type.

## Details
- `Me.userProfile` now references `MeUserProfile` directly.
- `MeUserProfile` is defined as `type: [object, 'null']` so Swift OpenAPI Generator emits `Components.Schemas.MeUserProfile?` at the usage site.\n- `userProfile` is included in `Me.required` because the API response should include the field even when the value is `null`.\n\n## Verification\n- `DEVELOPER_DIR="$(xcode-select -p)" xcrun swift build --scratch-path .build-verify`\n- Confirmed the previous OpenAPIKit warning for `nullable` no longer appears.\n- Confirmed the Swift OpenAPI Generator `Schema "null" is not supported` warning does not appear with the final schema shape.