### PR TITLE
Make SQL tables follow immutable data model

### DIFF
--- a/Database/init/create.sql
+++ b/Database/init/create.sql
@@ -10,28 +10,24 @@ CREATE TABLE public.passkey_credentials (
   id text NOT NULL,
   user_id uuid NOT NULL,
   public_key bytea NOT NULL,
-  sign_count bigint NOT NULL,
   created_at timestamptz NOT NULL DEFAULT now(),
-  updated_at timestamptz NOT NULL DEFAULT now(),
   CONSTRAINT passkey_credentials_pk PRIMARY KEY (id),
-  CONSTRAINT passkey_credentials_user_fk FOREIGN KEY (user_id) REFERENCES public.users (id) ON DELETE CASCADE,
-  CONSTRAINT sign_count_non_negative CHECK (sign_count >= 0)
+  CONSTRAINT passkey_credentials_user_fk FOREIGN KEY (user_id) REFERENCES public.users (id) ON DELETE RESTRICT
 );
 
 CREATE INDEX passkey_credentials_user_id_idx ON public.passkey_credentials(user_id);
 
-CREATE FUNCTION public.set_updated_at() RETURNS trigger
-  LANGUAGE plpgsql AS
-$$
-BEGIN
-  NEW.updated_at := now();
-  RETURN NEW;
-END;
-$$;
+CREATE TABLE public.passkey_credential_sign_counts (
+  id uuid NOT NULL,
+  passkey_credential_id text NOT NULL,
+  sign_count bigint NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT passkey_credential_sign_counts_pk PRIMARY KEY (id),
+  CONSTRAINT passkey_credential_sign_counts_passkey_credential_fk FOREIGN KEY (passkey_credential_id) REFERENCES public.passkey_credentials (id) ON DELETE RESTRICT,
+  CONSTRAINT passkey_credential_sign_counts_sign_count_non_negative CHECK (sign_count >= 0)
+);
 
-CREATE TRIGGER passkey_credentials_set_updated_at
-  BEFORE UPDATE ON public.passkey_credentials
-  FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+CREATE INDEX passkey_credential_sign_counts_latest_idx ON public.passkey_credential_sign_counts(passkey_credential_id, sign_count DESC, created_at DESC, id DESC);
 
 CREATE TABLE public.user_email (
   user_id uuid NOT NULL,
@@ -39,7 +35,7 @@ CREATE TABLE public.user_email (
   created_at timestamptz NOT NULL DEFAULT now(),
   CONSTRAINT user_email_pk PRIMARY KEY (user_id, email),
   CONSTRAINT user_email_email_key UNIQUE (email),
-  CONSTRAINT user_email_user_fk FOREIGN KEY (user_id) REFERENCES public.users (id) ON DELETE CASCADE
+  CONSTRAINT user_email_user_fk FOREIGN KEY (user_id) REFERENCES public.users (id) ON DELETE RESTRICT
 );
 
 CREATE TABLE public.images (
@@ -48,7 +44,7 @@ CREATE TABLE public.images (
   cloudflare_image_id text NOT NULL,
   created_at timestamptz NOT NULL DEFAULT now(),
   CONSTRAINT images_pk PRIMARY KEY (id),
-  CONSTRAINT images_user_fk FOREIGN KEY (user_id) REFERENCES public.users (id) ON DELETE CASCADE,
+  CONSTRAINT images_user_fk FOREIGN KEY (user_id) REFERENCES public.users (id) ON DELETE RESTRICT,
   CONSTRAINT images_cloudflare_image_id_key UNIQUE (cloudflare_image_id)
 );
 
@@ -61,7 +57,7 @@ CREATE TABLE public.user_profiles (
   name text NOT NULL,
   created_at timestamptz NOT NULL DEFAULT now(),
   CONSTRAINT user_profiles_pk PRIMARY KEY (id),
-  CONSTRAINT user_profiles_user_fk FOREIGN KEY (user_id) REFERENCES public.users (id) ON DELETE CASCADE,
+  CONSTRAINT user_profiles_user_fk FOREIGN KEY (user_id) REFERENCES public.users (id) ON DELETE RESTRICT,
   CONSTRAINT user_profiles_image_fk FOREIGN KEY (image_id) REFERENCES public.images (id),
   CONSTRAINT user_profiles_name_length CHECK (char_length(trim(name)) BETWEEN 1 AND 100)
 );

--- a/Sources/App/API/GetTokenFromPasskey.swift
+++ b/Sources/App/API/GetTokenFromPasskey.swift
@@ -73,11 +73,13 @@ extension API {
     let signCount: Int64?
     do {
       (passkeyCredential, signCount) = try await database.read { db in
-        let passkeyCredential = try await PasskeyCredential
+        let passkeyCredential =
+          try await PasskeyCredential
           .where { $0.id.eq(credential.id.asString()) }
           .fetchOne(db)
 
-        let signCount = try await PasskeyCredentialSignCount
+        let signCount =
+          try await PasskeyCredentialSignCount
           .where { $0.passkeyCredentialID.eq(credential.id.asString()) }
           .order { ($0.signCount.desc(), $0.id.desc()) }
           .select { $0.signCount }
@@ -135,7 +137,7 @@ extension API {
             signCount: Int64(verifiedAuthentication.newSignCount)
           )
         }
-          .execute(db)
+        .execute(db)
       }
     } catch {
       AppRequestContext.current?.logger.appError(

--- a/Sources/App/API/GetTokenFromPasskey.swift
+++ b/Sources/App/API/GetTokenFromPasskey.swift
@@ -4,6 +4,7 @@ import Hummingbird
 import Records
 import SQLKit
 import StructuredQueriesPostgres
+import UUIDV7
 import Valkey
 import WebAuthn
 
@@ -67,13 +68,23 @@ extension API {
       return .badRequest
     }
 
-    // 3. Load stored credential
+    // 3. Load stored credential and the highest observed sign counter
     let passkeyCredential: PasskeyCredential?
+    let signCount: Int64?
     do {
-      passkeyCredential = try await database.read { db in
-        try await PasskeyCredential
+      (passkeyCredential, signCount) = try await database.read { db in
+        let passkeyCredential = try await PasskeyCredential
           .where { $0.id.eq(credential.id.asString()) }
           .fetchOne(db)
+
+        let signCount = try await PasskeyCredentialSignCount
+          .where { $0.passkeyCredentialID.eq(credential.id.asString()) }
+          .order { ($0.signCount.desc(), $0.id.desc()) }
+          .select { $0.signCount }
+          .limit(1)
+          .fetchOne(db)
+
+        return (passkeyCredential, signCount)
       }
     } catch {
       AppRequestContext.current?.logger.appError(
@@ -87,12 +98,11 @@ extension API {
       return .badRequest
     }
 
-    guard let passkeyCredential else {
+    guard let passkeyCredential, let signCount else {
       return .badRequest
     }
 
     let userID = passkeyCredential.userID
-    let signCount = passkeyCredential.signCount
 
     // 4. Verify assertion with WebAuthn
     let verifiedAuthentication: VerifiedAuthentication
@@ -115,24 +125,24 @@ extension API {
       return .badRequest
     }
 
-    // 5. Update stored sign counter
+    // 5. Append observed sign counter
     do {
       try await database.write { db in
-        try await PasskeyCredential
-          .update {
-            $0.signCount = #sql(
-              "GREATEST(\($0.signCount), \(Int64(verifiedAuthentication.newSignCount)))"
-            )
-          }
-          .where { $0.id.eq(verifiedAuthentication.credentialID.asString()) }
+        try await PasskeyCredentialSignCount.insert {
+          PasskeyCredentialSignCount(
+            id: UUID(uuidString: UUID.uuidV7String())!,
+            passkeyCredentialID: verifiedAuthentication.credentialID.asString(),
+            signCount: Int64(verifiedAuthentication.newSignCount)
+          )
+        }
           .execute(db)
       }
     } catch {
       AppRequestContext.current?.logger.appError(
-        eventName: "auth.passkey.sign_count_update_failed",
-        "Failed to update stored sign counter",
+        eventName: "auth.passkey.sign_count_append_failed",
+        "Failed to append observed sign counter",
         metadata: AppLogMetadata.userID(userID).merging([
-          "db.operation": .string("update"),
+          "db.operation": .string("insert"),
           "webauthn.sign_count": .stringConvertible(signCount),
           "webauthn.new_sign_count": .stringConvertible(verifiedAuthentication.newSignCount),
         ]) { _, new in new },

--- a/Sources/App/API/Passkey.swift
+++ b/Sources/App/API/Passkey.swift
@@ -103,8 +103,6 @@ extension API {
 
         try await PasskeyCredential.insert {
           passkeyCredential
-        } onConflict: {
-          $0.id
         }
         .execute(db)
 

--- a/Sources/App/API/Passkey.swift
+++ b/Sources/App/API/Passkey.swift
@@ -5,6 +5,7 @@ import PostgresNIO
 import Records
 import SQLKit
 import StructuredQueriesPostgres
+import UUIDV7
 import Valkey
 import WebAuthn
 
@@ -94,15 +95,25 @@ extension API {
     // 4. Persist credential metadata
     do {
       try await database.write { db in
+        let passkeyCredential = PasskeyCredential(
+          id: registrationCredential.id.asString(),
+          userID: userID,
+          publicKey: Data(credential.publicKey)
+        )
+
         try await PasskeyCredential.insert {
-          PasskeyCredential(
-            id: registrationCredential.id.asString(),
-            userID: userID,
-            publicKey: Data(credential.publicKey),
-            signCount: Int64(credential.signCount)
-          )
+          passkeyCredential
         } onConflict: {
           $0.id
+        }
+        .execute(db)
+
+        try await PasskeyCredentialSignCount.insert {
+          PasskeyCredentialSignCount(
+            id: UUID(uuidString: UUID.uuidV7String())!,
+            passkeyCredentialID: passkeyCredential.id,
+            signCount: Int64(credential.signCount)
+          )
         }
         .execute(db)
       }

--- a/Sources/App/Model/PasskeyCredential.swift
+++ b/Sources/App/Model/PasskeyCredential.swift
@@ -6,5 +6,11 @@ struct PasskeyCredential {
   var id: String
   @Column("user_id") var userID: UUID
   @Column("public_key") var publicKey: Data
+}
+
+@Table("passkey_credential_sign_counts")
+struct PasskeyCredentialSignCount {
+  var id: UUID
+  @Column("passkey_credential_id") var passkeyCredentialID: String
   @Column("sign_count") var signCount: Int64
 }


### PR DESCRIPTION
## Summary
- move WebAuthn passkey sign counts into an append-only history table
- remove mutable sign_count/updated_at handling and UPDATE trigger from passkey credentials
- replace cascading foreign-key deletes with RESTRICT to avoid implicit history deletion