### PR TITLE
Fix Atlas migration revision schema

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -81,7 +81,7 @@ jobs:
 
           atlas migrate apply \
             --env production \
-            --var "database_url=postgres://${POSTGRES_USER_ENCODED}:${POSTGRES_PASSWORD_ENCODED}@${POSTGRES_HOSTNAME}:5432/${POSTGRES_DB_ENCODED}?sslmode=require" \
+            --var "database_url=postgres://${POSTGRES_USER_ENCODED}:${POSTGRES_PASSWORD_ENCODED}@${POSTGRES_HOSTNAME}:5432/${POSTGRES_DB_ENCODED}?sslmode=require&search_path=public" \
             "${baseline_args[@]}"
 
       - name: Update Cloud Run service image


### PR DESCRIPTION
## Summary

- Add `search_path=public` to the production Atlas migration database URL.

## Why

The first `atlas migrate apply` run failed while reading the revision table:

```text
pq: relation "atlas_schema_revisions.atlas_schema_revisions" does not exist
```

Without a schema-bound PostgreSQL URL, Atlas stores revision metadata in its default `atlas_schema_revisions` schema. Binding the URL to `public` makes Atlas use `public.atlas_schema_revisions`, matching the app schema and avoiding the failed lookup.

## Validation

- Parsed `.github/workflows/deploy.yml` as YAML locally.
