### PR TITLE
Remove Grafana Online telemetry

### DIFF
--- a/Deploy/cloud-run/collector-config.yaml
+++ b/Deploy/cloud-run/collector-config.yaml
@@ -43,10 +43,6 @@ exporters:
     log:
       default_log_name: blindlog-api
   googlemanagedprometheus:
-  otlphttp/grafana:
-    endpoint: ${env:GRAFANA_OTLP_ENDPOINT}
-    headers:
-      authorization: "Basic ${env:GRAFANA_OTLP_AUTH}"
 
 extensions:
   health_check:
@@ -59,12 +55,12 @@ service:
     logs:
       receivers: [otlp]
       processors: [resourcedetection, memory_limiter, batch]
-      exporters: [googlecloud, otlphttp/grafana]
+      exporters: [googlecloud]
     metrics/otlp:
       receivers: [otlp]
       processors: [resourcedetection, transform/collision, memory_limiter, batch]
-      exporters: [googlemanagedprometheus, otlphttp/grafana]
+      exporters: [googlemanagedprometheus]
     traces:
       receivers: [otlp]
       processors: [resourcedetection, memory_limiter, batch]
-      exporters: [googlecloud, otlphttp/grafana]
+      exporters: [googlecloud]

--- a/Terraform/README.md
+++ b/Terraform/README.md
@@ -109,10 +109,6 @@ terraform import 'google_secret_manager_secret.app["OTP_SECRET_KEY"]' \
 # OTel Collector config secret (手動作成済みの場合のみ)
 terraform import google_secret_manager_secret.otel_collector_config \
   "projects/$PROJECT_ID/secrets/blindlog-otel-collector-config"
-
-# Grafana Cloud OTLP auth secret (手動作成済みの場合のみ)
-terraform import google_secret_manager_secret.grafana_otlp_auth \
-  "projects/$PROJECT_ID/secrets/GRAFANA_OTLP_AUTH"
 ```
 
 (既存の secret_id が上と違う場合は Google Cloud コンソールで確認して合わせる。)
@@ -150,10 +146,6 @@ printf '%s' "<VALKEY_PASSWORD_VALUE>"      | gcloud secrets versions add VALKEY_
 printf '%s' "<EDDSA_PRIVATE_KEY_VALUE>"    | gcloud secrets versions add EDDSA_PRIVATE_KEY    --data-file=-
 printf '%s' "<CLOUDFLARE_API_TOKEN_VALUE>" | gcloud secrets versions add CLOUDFLARE_API_TOKEN --data-file=-
 printf '%s' "<OTP_SECRET_KEY_VALUE>"       | gcloud secrets versions add OTP_SECRET_KEY       --data-file=-
-
-# Grafana Cloud OTLP Basic-auth header (only if grafana_otlp_endpoint is set)
-printf '%s' "$INSTANCE_ID:$API_TOKEN" | base64 | \
-  gcloud secrets versions add GRAFANA_OTLP_AUTH --data-file=-
 ```
 
 ### 10. 全体を `terraform apply`

--- a/Terraform/cloud_run.tf
+++ b/Terraform/cloud_run.tf
@@ -1,7 +1,6 @@
 resource "google_cloud_run_v2_service" "api" {
   depends_on = [
     google_project_service.required,
-    google_secret_manager_secret_iam_member.grafana_otlp_auth_runtime_access,
     google_secret_manager_secret_iam_member.otel_collector_config_runtime_access,
     google_secret_manager_secret_version.otel_collector_config,
     google_secret_manager_secret_iam_member.runtime_access,
@@ -86,24 +85,6 @@ resource "google_cloud_run_v2_service" "api" {
         }
         cpu_idle          = var.cpu_idle
         startup_cpu_boost = true
-      }
-
-      # Grafana Cloud OTLP fan-out. The collector references both env vars
-      # via ${env:VAR} substitution in collector-config.yaml. Endpoint is
-      # plaintext; the auth header (Basic base64(instanceID:apiToken)) is a
-      # secret. Setting var.grafana_otlp_endpoint to "" disables the export.
-      env {
-        name  = "GRAFANA_OTLP_ENDPOINT"
-        value = var.grafana_otlp_endpoint
-      }
-      env {
-        name = "GRAFANA_OTLP_AUTH"
-        value_source {
-          secret_key_ref {
-            secret  = google_secret_manager_secret.grafana_otlp_auth.secret_id
-            version = "latest"
-          }
-        }
       }
 
       startup_probe {

--- a/Terraform/secrets.tf
+++ b/Terraform/secrets.tf
@@ -51,26 +51,3 @@ resource "google_secret_manager_secret_iam_member" "otel_collector_config_runtim
   role      = "roles/secretmanager.secretAccessor"
   member    = "serviceAccount:${google_service_account.runtime.email}"
 }
-
-# Grafana Cloud OTLP Basic-auth header value, base64(instanceID:apiToken).
-# Versions are uploaded out-of-band (`gcloud secrets versions add ...`); Terraform
-# only manages the secret container and IAM binding.
-resource "google_secret_manager_secret" "grafana_otlp_auth" {
-  depends_on = [google_project_service.required]
-
-  secret_id = var.grafana_otlp_auth_secret_id
-
-  replication {
-    auto {}
-  }
-
-  lifecycle {
-    prevent_destroy = true
-  }
-}
-
-resource "google_secret_manager_secret_iam_member" "grafana_otlp_auth_runtime_access" {
-  secret_id = google_secret_manager_secret.grafana_otlp_auth.id
-  role      = "roles/secretmanager.secretAccessor"
-  member    = "serviceAccount:${google_service_account.runtime.email}"
-}

--- a/Terraform/terraform.tfvars.example
+++ b/Terraform/terraform.tfvars.example
@@ -24,13 +24,6 @@ cloudflare_zone_id = "0123456789abcdef0123456789abcdef"
 # allow_unauthenticated = true
 # restrict_direct_cloud_run_ingress = false # Set to true after api_hostname works through the load balancer.
 
-# Grafana Cloud OTLP fan-out. Leave empty to disable.
-# Endpoint: get from Grafana Cloud Portal -> Stack -> Connections -> OpenTelemetry (OTLP) -> Configure.
-# Auth: upload `printf '%s' "$INSTANCE_ID:$API_TOKEN" | base64` as a Secret Manager
-# version of the secret named by grafana_otlp_auth_secret_id (default: GRAFANA_OTLP_AUTH).
-# grafana_otlp_endpoint        = "https://otlp-gateway-prod-ap-northeast-0.grafana.net/otlp"
-# grafana_otlp_auth_secret_id  = "GRAFANA_OTLP_AUTH"
-
 # First `terraform apply` uses this tag. After that, GitHub Actions overrides
 # the running image with `gcloud run services update --image=...:<sha>`, and
 # Terraform ignores image drift (see cloud_run.tf lifecycle block).

--- a/Terraform/variables.tf
+++ b/Terraform/variables.tf
@@ -66,18 +66,6 @@ variable "github_repo" {
   }
 }
 
-variable "grafana_otlp_auth_secret_id" {
-  description = "Secret Manager secret ID storing the Basic-auth header value (base64(instanceID:apiToken)) for Grafana Cloud OTLP."
-  type        = string
-  default     = "GRAFANA_OTLP_AUTH"
-}
-
-variable "grafana_otlp_endpoint" {
-  description = "Grafana Cloud OTLP HTTP endpoint, e.g. \"https://otlp-gateway-prod-ap-northeast-0.grafana.net/otlp\". Set to an empty string to disable the Grafana exporter."
-  type        = string
-  default     = ""
-}
-
 variable "image_tag" {
   description = "Initial image tag used on `terraform apply`. After first apply, GitHub Actions updates the running tag; Terraform ignores image drift."
   type        = string


### PR DESCRIPTION
## Summary
- remove the Grafana OTLP exporter from the OpenTelemetry collector config
- remove Grafana Cloud endpoint/auth environment wiring from Cloud Run
- remove Terraform-managed Grafana auth secret, variables, and setup docs

Closes #177

## Validation
- terraform -chdir=Terraform fmt -check
- terraform -chdir=Terraform validate
- rg -n --no-ignore "Grafana|grafana|GRAFANA" Deploy Terraform