### PR TITLE
Cache CI build artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,13 @@ jobs:
         uses: actions/checkout@v6.0.2
       - name: Start DB, Cache & OTel Collector (wait for health)
         run: docker compose up -d --wait postgres valkey otel-collector
+      - name: Cache SwiftPM build artifacts
+        uses: actions/cache@v4
+        with:
+          path: .build
+          key: ${{ runner.os }}-swift-6.3.2-${{ hashFiles('Package.swift', 'Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-swift-6.3.2-
       - name: Run tests (Swift in Docker)
         run: docker compose run --rm swift bash -lc "apt-get update && apt-get install -y libssl-dev && swift test --parallel"
       - name: Shutdown
@@ -39,7 +46,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.2
-      - run: docker build .
+      - uses: docker/setup-buildx-action@v4.1.0
+      - name: Build image
+        uses: docker/build-push-action@v7.2.0
+        with:
+          context: .
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
   terraform:
     runs-on: ubuntu-latest
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,17 @@
+# syntax=docker/dockerfile:1.7
+
 # ================================
 # Build image
 # ================================
 FROM swift:6.3.2-noble AS build
 
 # Install OS updates
-RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true \
     && apt-get -q update \
     && apt-get -q dist-upgrade -y \
-    && apt-get install -y libjemalloc-dev libssl-dev \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get install -y libjemalloc-dev libssl-dev
 
 # Set up a build area
 WORKDIR /build
@@ -18,13 +21,17 @@ WORKDIR /build
 # as long as your Package.swift/Package.resolved
 # files do not change.
 COPY ./Package.* ./
-RUN swift package resolve
+RUN --mount=type=cache,target=/build/.build,sharing=locked \
+    --mount=type=cache,target=/root/.cache,sharing=locked \
+    swift package resolve
 
 # Copy entire repo into container
 COPY . .
 
 # Build the application, with optimizations, with static linking, and using jemalloc
-RUN swift build -c release \
+RUN --mount=type=cache,target=/build/.build,sharing=locked \
+    --mount=type=cache,target=/root/.cache,sharing=locked \
+    swift build -c release \
     --product "App" \
     --static-swift-stdlib \
     -Xlinker -ljemalloc
@@ -33,13 +40,15 @@ RUN swift build -c release \
 WORKDIR /staging
 
 # Copy main executable to staging area
-RUN cp "$(swift build --package-path /build -c release --show-bin-path)/App" ./
+RUN --mount=type=cache,target=/build/.build,sharing=locked \
+    cp "$(swift build --package-path /build -c release --show-bin-path)/App" ./
 
 # Copy static swift backtracer binary to staging area
 RUN cp "/usr/libexec/swift/linux/swift-backtrace-static" ./
 
 # Copy resources bundled by SPM to staging area
-RUN find -L "$(swift build --package-path /build -c release --show-bin-path)/" -regex '.*\.resources$' -exec cp -Ra {} ./ \;
+RUN --mount=type=cache,target=/build/.build,sharing=locked \
+    find -L "$(swift build --package-path /build -c release --show-bin-path)/" -regex '.*\.resources$' -exec cp -Ra {} ./ \;
 
 # Copy any resouces from the public directory and views directory if the directories exist
 # Ensure that by default, neither the directory nor any of its contents are writable.
@@ -51,7 +60,9 @@ RUN [ -d /build/public ] && { mv /build/public ./public && chmod -R a-w ./public
 FROM ubuntu:noble
 
 # Make sure all system packages are up to date, and install only essential packages.
-RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true \
     && apt-get -q update \
     && apt-get -q dist-upgrade -y \
     && apt-get -q install -y \
@@ -61,8 +72,7 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true \
 # If your app or its dependencies import FoundationNetworking, also install `libcurl4`.
       libcurl4 \
 # If your app or its dependencies import FoundationXML, also install `libxml2`.
-      libxml2 \
-    && rm -r /var/lib/apt/lists/*
+      libxml2
 
 # Create a hummingbird user and group with /app as its home directory
 RUN useradd --user-group --create-home --system --skel /dev/null --home-dir /app hummingbird

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.7
+# syntax=docker/dockerfile:1
 
 # ================================
 # Build image


### PR DESCRIPTION
## Summary
- cache SwiftPM .build artifacts for the Docker-based test job
- switch the CI Docker build job to Buildx with GitHub Actions cache
- enable BuildKit apt cache mounts in the Dockerfile

Closes #176

## Validation
- actionlint .github/workflows/ci.yml .github/workflows/deploy.yml

## Notes
- Docker and SwiftPM cache benefits are expected to be most visible on repeated CI runs after the first cache is written.