### PR TITLE
Add refresh token revoke API

### DIFF
--- a/Sources/App/API/GenerateUserToken.swift
+++ b/Sources/App/API/GenerateUserToken.swift
@@ -9,6 +9,7 @@ extension API {
 
     let tokenPayload = JWTPayloadData(
       tokenType: .token,
+      id: .init(value: UUID().uuidString),
       subject: .init(value: userID.uuidString),
       expiration: .init(value: tokenExpiredDate),
     )
@@ -17,6 +18,7 @@ extension API {
 
     let refreshTokenPayload = JWTPayloadData(
       tokenType: .refreshToken,
+      id: .init(value: UUID().uuidString),
       subject: .init(value: userID.uuidString),
       expiration: .init(value: refreshTokenExpiredDate),
     )

--- a/Sources/App/API/RefreshToken.swift
+++ b/Sources/App/API/RefreshToken.swift
@@ -44,6 +44,28 @@ extension API {
       return .unauthorized
     }
 
+    do {
+      guard try await !isRefreshTokenRevoked(payload) else {
+        AppRequestContext.current?.logger.appLog(
+          level: .debug,
+          eventName: "auth.refresh_token.revoked",
+          "Refresh token has been revoked",
+          metadata: AppLogMetadata.userID(userID)
+        )
+        return .unauthorized
+      }
+    } catch {
+      AppRequestContext.current?.logger.appError(
+        eventName: "auth.refresh_token.revoke_status_read_failed",
+        "Failed to read refresh token revoke status",
+        metadata: AppLogMetadata.userID(userID).merging([
+          "cache.operation": .string("exists")
+        ]) { _, new in new },
+        error: error
+      )
+      return .badRequest
+    }
+
     let userToken: Components.Schemas.UserToken
     do {
       userToken = try await generateUserToken(userID: userID)
@@ -59,5 +81,87 @@ extension API {
       return .badRequest
     }
     return .ok(.init(body: .json(userToken)))
+  }
+
+  func revokeToken(
+    _ input: Operations.RevokeToken.Input
+  ) async throws -> Operations.RevokeToken.Output {
+    guard case .json(let body) = input.body else {
+      return .badRequest
+    }
+
+    let payload: JWTPayloadData
+    do {
+      payload = try await jwtKeyCollection.verify(body.refreshToken, as: JWTPayloadData.self)
+    } catch {
+      AppRequestContext.current?.logger.appLog(
+        level: .debug,
+        eventName: "auth.revoke_token.verify_failed",
+        "Couldn't verify refresh token",
+        error: error
+      )
+      return .unauthorized
+    }
+
+    guard let userID = UUID(uuidString: payload.subject.value) else {
+      AppRequestContext.current?.logger.appLog(
+        level: .debug,
+        eventName: "auth.revoke_token.invalid_subject",
+        "Invalid JWT subject"
+      )
+      return .unauthorized
+    }
+    guard payload.expiration.value > Date() else {
+      AppRequestContext.current?.logger.appLog(
+        level: .debug,
+        eventName: "auth.revoke_token.expired",
+        "Refresh token expired",
+        metadata: AppLogMetadata.userID(userID)
+      )
+      return .unauthorized
+    }
+    guard payload.tokenType == .refreshToken else {
+      AppRequestContext.current?.logger.appLog(
+        level: .debug,
+        eventName: "auth.revoke_token.invalid_type",
+        "Token type is not refresh token",
+        metadata: AppLogMetadata.userID(userID)
+      )
+      return .unauthorized
+    }
+
+    do {
+      try await revokeRefreshToken(payload)
+    } catch {
+      AppRequestContext.current?.logger.appError(
+        eventName: "auth.revoke_token.cache_write_failed",
+        "Failed to write revoked refresh token",
+        metadata: AppLogMetadata.userID(userID).merging([
+          "cache.operation": .string("set")
+        ]) { _, new in new },
+        error: error
+      )
+      return .badRequest
+    }
+
+    return .ok(.init())
+  }
+
+  fileprivate func isRefreshTokenRevoked(_ payload: JWTPayloadData) async throws -> Bool {
+    try await cache.exists(keys: [revokedRefreshTokenCacheKey(payload)]) > 0
+  }
+
+  fileprivate func revokeRefreshToken(_ payload: JWTPayloadData) async throws {
+    let remainingLifetime = Int(payload.expiration.value.timeIntervalSinceNow.rounded(.up))
+    guard remainingLifetime > 0 else { return }
+    try await cache.set(
+      revokedRefreshTokenCacheKey(payload),
+      value: Data("1".utf8),
+      expiration: .seconds(remainingLifetime)
+    )
+  }
+
+  fileprivate func revokedRefreshTokenCacheKey(_ payload: JWTPayloadData) -> ValkeyKey {
+    ValkeyKey("revoked_refresh_token:\(payload.id.value)")
   }
 }

--- a/Sources/App/Model/JWTPayloadData.swift
+++ b/Sources/App/Model/JWTPayloadData.swift
@@ -2,6 +2,7 @@ import JWTKit
 
 struct JWTPayloadData: JWTPayload, Equatable {
   var tokenType: TokenType
+  var id: IDClaim
   var subject: SubjectClaim
   var expiration: ExpirationClaim
 
@@ -11,6 +12,7 @@ struct JWTPayloadData: JWTPayload, Equatable {
 
   enum CodingKeys: String, CodingKey {
     case tokenType
+    case id = "jti"
     case subject = "sub"
     case expiration = "exp"
   }

--- a/Tests/AppTests/RouterTests.swift
+++ b/Tests/AppTests/RouterTests.swift
@@ -713,6 +713,78 @@ struct RouterTests {
   }
 
   @Test
+  func revokeToken() async throws {
+    let arguments = TestArguments()
+    let app = try await buildApplication(arguments)
+    let ipAddress = UUID().uuidString
+
+    try await app.test(.router) { client in
+      let newUserResponse = try await client.execute(
+        uri: "/user",
+        method: .post,
+        headers: [
+          .cfConnectingIP: ipAddress
+        ]
+      )
+      #expect(newUserResponse.status == .ok)
+      let newUser = try JSONDecoder().decode(
+        Components.Schemas.UserToken.self,
+        from: newUserResponse.body
+      )
+
+      let revokeResponse = try await client.execute(
+        uri: "/revokeToken",
+        method: .post,
+        headers: [
+          .cfConnectingIP: ipAddress
+        ],
+        body: ByteBuffer(data: JSONEncoder().encode(["refreshToken": newUser.refreshToken]))
+      )
+      #expect(revokeResponse.status == .ok)
+
+      let revokedRefreshResponse = try await client.execute(
+        uri: "/refreshToken",
+        method: .post,
+        headers: [
+          .cfConnectingIP: ipAddress
+        ],
+        body: ByteBuffer(data: JSONEncoder().encode(["refreshToken": newUser.refreshToken]))
+      )
+      #expect(revokedRefreshResponse.status == .unauthorized)
+
+      let getMeResponse = try await client.execute(
+        uri: "/me",
+        method: .get,
+        headers: [
+          .cfConnectingIP: ipAddress,
+          .authorization: "Bearer \(newUser.token)",
+        ]
+      )
+      #expect(getMeResponse.status == .ok)
+
+      let accessTokenRevokeResponse = try await client.execute(
+        uri: "/revokeToken",
+        method: .post,
+        headers: [
+          .cfConnectingIP: ipAddress
+        ],
+        body: ByteBuffer(data: JSONEncoder().encode(["refreshToken": newUser.token]))
+      )
+      #expect(accessTokenRevokeResponse.status == .unauthorized)
+
+      let invalidTokenRevokeResponse = try await client.execute(
+        uri: "/revokeToken",
+        method: .post,
+        headers: [
+          .cfConnectingIP: ipAddress
+        ],
+        body: ByteBuffer(data: JSONEncoder().encode(["refreshToken": "invalid-token"]))
+      )
+      #expect(invalidTokenRevokeResponse.status == .unauthorized)
+    }
+  }
+
+  @Test
   func challengeForRegistration() async throws {
     let arguments = TestArguments()
     let app = try await buildApplication(arguments)

--- a/public/documents/openapi.yml
+++ b/public/documents/openapi.yml
@@ -164,6 +164,28 @@ paths:
           description: A bad request
         '401':
           description: Not Authorization
+  /revokeToken:
+    post:
+      operationId: revokeToken
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                refreshToken:
+                  type: string
+                  description: User refresh token.
+              required:
+                - refreshToken
+      responses:
+        '200':
+          description: A success response.
+        '400':
+          description: A bad request
+        '401':
+          description: Not Authorization
   /me:
     get:
       operationId: getMe


### PR DESCRIPTION
Closes #44

## Summary
- add POST /revokeToken to revoke refresh tokens
- add jti to issued JWTs and store revoked refresh token IDs in Valkey until expiration
- reject revoked refresh tokens in /refreshToken while leaving existing access tokens valid