### PR TITLE
Add user event list APIs

### DIFF
--- a/Sources/App/API/Events.swift
+++ b/Sources/App/API/Events.swift
@@ -46,6 +46,60 @@ extension API {
     }
   }
 
+  func getUserOrganizedEvents(
+    _ input: Operations.GetUserOrganizedEvents.Input
+  ) async throws -> Operations.GetUserOrganizedEvents.Output {
+    guard let requesterUserID = UserTokenContext.currentUserID else {
+      return .unauthorized
+    }
+    guard let userID = UUID(uuidString: input.path.userId) else {
+      return .badRequest
+    }
+
+    do {
+      let events = try await latestUserOrganizedEvents(
+        userID: userID,
+        requesterUserID: requesterUserID
+      )
+      return .ok(.init(body: .json(events.map(Components.Schemas.Event.init))))
+    } catch {
+      logEventDatabaseError(
+        "event.user_organized_list_failed",
+        "Failed to fetch user organized events",
+        userID: requesterUserID,
+        error: error
+      )
+      return .badRequest
+    }
+  }
+
+  func getUserParticipatingEvents(
+    _ input: Operations.GetUserParticipatingEvents.Input
+  ) async throws -> Operations.GetUserParticipatingEvents.Output {
+    guard let requesterUserID = UserTokenContext.currentUserID else {
+      return .unauthorized
+    }
+    guard let userID = UUID(uuidString: input.path.userId) else {
+      return .badRequest
+    }
+
+    do {
+      let events = try await latestUserParticipatingEvents(
+        userID: userID,
+        requesterUserID: requesterUserID
+      )
+      return .ok(.init(body: .json(events.map(Components.Schemas.Event.init))))
+    } catch {
+      logEventDatabaseError(
+        "event.user_participating_list_failed",
+        "Failed to fetch user participating events",
+        userID: requesterUserID,
+        error: error
+      )
+      return .badRequest
+    }
+  }
+
   func createEvent(
     _ input: Operations.CreateEvent.Input
   ) async throws -> Operations.CreateEvent.Output {
@@ -706,6 +760,128 @@ extension API {
         .fetchAll(db)
       return rows.map { event, revision in
         EventSnapshot(event: event, revision: revision)
+      }
+    }
+  }
+
+  fileprivate func latestUserOrganizedEvents(
+    userID: UUID,
+    requesterUserID: UUID
+  ) async throws -> [EventSnapshot] {
+    try await database.read { db in
+      if userID == requesterUserID {
+        let rows =
+          try await EventRecord
+          .where { $0.organizerUserID.eq(userID) }
+          .joinLateral { event in
+            EventRevisionRecord
+              .where { $0.eventID.eq(event.id) }
+              .order { ($0.createdAt.desc(), $0.id.desc()) }
+              .limit(1)
+          }
+          .order { event, revision in
+            (revision.startsAt.desc(), event.id.desc())
+          }
+          .selectStar()
+          .fetchAll(db)
+        return rows.map { event, revision in
+          EventSnapshot(event: event, revision: revision)
+        }
+      } else {
+        let rows =
+          try await EventRecord
+          .where { $0.organizerUserID.eq(userID) }
+          .joinLateral { event in
+            EventRevisionRecord
+              .where { $0.eventID.eq(event.id) }
+              .order { ($0.createdAt.desc(), $0.id.desc()) }
+              .limit(1)
+          }
+          .where { _, revision in
+            revision.visibility.eq(EventRecord.Visibility.public)
+              .and(revision.publishedAt.isNot(nil))
+              .and(revision.canceledAt.is(nil))
+          }
+          .order { event, revision in
+            (revision.startsAt.desc(), event.id.desc())
+          }
+          .selectStar()
+          .fetchAll(db)
+        return rows.map { event, revision in
+          EventSnapshot(event: event, revision: revision)
+        }
+      }
+    }
+  }
+
+  fileprivate func latestUserParticipatingEvents(
+    userID: UUID,
+    requesterUserID: UUID
+  ) async throws -> [EventSnapshot] {
+    try await database.read { db in
+      if userID == requesterUserID {
+        let rows =
+          try await EventRecord
+          .join(EventParticipantRecord.all) { event, participant in
+            event.id.eq(participant.eventID)
+          }
+          .joinLateral { event, _ in
+            EventRevisionRecord
+              .where { $0.eventID.eq(event.id) }
+              .order { ($0.createdAt.desc(), $0.id.desc()) }
+              .limit(1)
+          }
+          .where { _, participant, _ in
+            participant.userID.eq(userID)
+              .and(
+                participant.status.in([
+                  EventParticipantRecord.Status.registered,
+                  .waitlisted,
+                  .attended,
+                ])
+              )
+          }
+          .order { event, _, revision in
+            (revision.startsAt.desc(), event.id.desc())
+          }
+          .selectStar()
+          .fetchAll(db)
+        return rows.map { event, _, revision in
+          EventSnapshot(event: event, revision: revision)
+        }
+      } else {
+        let rows =
+          try await EventRecord
+          .join(EventParticipantRecord.all) { event, participant in
+            event.id.eq(participant.eventID)
+          }
+          .joinLateral { event, _ in
+            EventRevisionRecord
+              .where { $0.eventID.eq(event.id) }
+              .order { ($0.createdAt.desc(), $0.id.desc()) }
+              .limit(1)
+          }
+          .where { _, participant, revision in
+            participant.userID.eq(userID)
+              .and(
+                participant.status.in([
+                  EventParticipantRecord.Status.registered,
+                  .waitlisted,
+                  .attended,
+                ])
+              )
+              .and(revision.visibility.eq(EventRecord.Visibility.public))
+              .and(revision.publishedAt.isNot(nil))
+              .and(revision.canceledAt.is(nil))
+          }
+          .order { event, _, revision in
+            (revision.startsAt.desc(), event.id.desc())
+          }
+          .selectStar()
+          .fetchAll(db)
+        return rows.map { event, _, revision in
+          EventSnapshot(event: event, revision: revision)
+        }
       }
     }
   }

--- a/Tests/AppTests/RouterTests.swift
+++ b/Tests/AppTests/RouterTests.swift
@@ -609,6 +609,183 @@ struct RouterTests {
   }
 
   @Test
+  func userEventListsSeparateOrganizedAndParticipatingEvents() async throws {
+    let arguments = TestArguments()
+    let app = try await buildApplication(arguments)
+    let ipAddress = UUID().uuidString
+    let now = Date().timeIntervalSinceReferenceDate
+
+    try await app.test(.router) { client in
+      func createUser() async throws -> Components.Schemas.UserToken {
+        try await client.execute(
+          uri: "/user",
+          method: .post,
+          headers: [
+            .cfConnectingIP: ipAddress
+          ]
+        ) { response in
+          #expect(response.status == .ok)
+          return try JSONDecoder().decode(Components.Schemas.UserToken.self, from: response.body)
+        }
+      }
+
+      func eventRequest(
+        title: String,
+        startsAt: Double,
+        visibility: Components.Schemas.EventVisibility,
+        publishedAt: Double?,
+        canceledAt: Double? = nil
+      ) -> Components.Schemas.CreateEventRequest {
+        .init(
+          title: title,
+          body: "\(title) body",
+          venueName: "Blind Tasting Room",
+          venueAddress: .init(addressLine1: "1 Wine Street", countryCode: "JP"),
+          eventPeriod: .init(startsAt: startsAt, endsAt: startsAt + 3600),
+          visibility: visibility,
+          publishedAt: publishedAt,
+          canceledAt: canceledAt
+        )
+      }
+
+      func createEvent(
+        token: String,
+        title: String,
+        startsAt: Double,
+        visibility: Components.Schemas.EventVisibility,
+        publishedAt: Double?,
+        canceledAt: Double? = nil
+      ) async throws -> Components.Schemas.Event {
+        let body = eventRequest(
+          title: title,
+          startsAt: startsAt,
+          visibility: visibility,
+          publishedAt: publishedAt,
+          canceledAt: canceledAt
+        )
+        return try await client.execute(
+          uri: "/events",
+          method: .post,
+          headers: [
+            .cfConnectingIP: ipAddress,
+            .authorization: "Bearer \(token)",
+          ],
+          body: ByteBuffer(data: JSONEncoder().encode(body))
+        ) { response in
+          #expect(response.status == .ok)
+          return try JSONDecoder().decode(Components.Schemas.Event.self, from: response.body)
+        }
+      }
+
+      func getEvents(uri: String, token: String) async throws -> [Components.Schemas.Event] {
+        try await client.execute(
+          uri: uri,
+          method: .get,
+          headers: [
+            .cfConnectingIP: ipAddress,
+            .authorization: "Bearer \(token)",
+          ]
+        ) { response in
+          #expect(response.status == .ok)
+          return try JSONDecoder().decode([Components.Schemas.Event].self, from: response.body)
+        }
+      }
+
+      let organizer = try await createUser()
+      let participant = try await createUser()
+      let viewer = try await createUser()
+
+      let privateDraft = try await createEvent(
+        token: organizer.token,
+        title: "Private draft",
+        startsAt: now + 1000,
+        visibility: ._private,
+        publishedAt: nil
+      )
+      let publicEvent = try await createEvent(
+        token: organizer.token,
+        title: "Public event",
+        startsAt: now + 2000,
+        visibility: ._public,
+        publishedAt: now
+      )
+      let unlistedEvent = try await createEvent(
+        token: organizer.token,
+        title: "Unlisted event",
+        startsAt: now + 3000,
+        visibility: .unlisted,
+        publishedAt: now
+      )
+      let canceledPublicEvent = try await createEvent(
+        token: organizer.token,
+        title: "Canceled public event",
+        startsAt: now + 4000,
+        visibility: ._public,
+        publishedAt: now,
+        canceledAt: now
+      )
+
+      for eventID in [publicEvent.id, unlistedEvent.id] {
+        let response = try await client.execute(
+          uri: "/events/\(eventID)/participants",
+          method: .post,
+          headers: [
+            .cfConnectingIP: ipAddress,
+            .authorization: "Bearer \(participant.token)",
+          ]
+        )
+        #expect(response.status == .ok)
+      }
+
+      let organizerOwnEvents = try await getEvents(
+        uri: "/users/\(organizer.userID)/organized_events",
+        token: organizer.token
+      )
+      #expect(
+        Set(organizerOwnEvents.map(\.id))
+          == Set([privateDraft.id, publicEvent.id, unlistedEvent.id, canceledPublicEvent.id])
+      )
+
+      let organizerPublicEvents = try await getEvents(
+        uri: "/users/\(organizer.userID)/organized_events",
+        token: viewer.token
+      )
+      #expect(organizerPublicEvents.map(\.id) == [publicEvent.id])
+
+      let participantOwnEvents = try await getEvents(
+        uri: "/users/\(participant.userID)/participating_events",
+        token: participant.token
+      )
+      #expect(Set(participantOwnEvents.map(\.id)) == Set([publicEvent.id, unlistedEvent.id]))
+
+      let participantPublicEvents = try await getEvents(
+        uri: "/users/\(participant.userID)/participating_events",
+        token: viewer.token
+      )
+      #expect(participantPublicEvents.map(\.id) == [publicEvent.id])
+
+      let invalidUUIDResponse = try await client.execute(
+        uri: "/users/not-a-uuid/organized_events",
+        method: .get,
+        headers: [
+          .cfConnectingIP: ipAddress,
+          .authorization: "Bearer \(viewer.token)",
+        ]
+      )
+      #expect(invalidUUIDResponse.status == .badRequest)
+
+      let unauthenticatedResponse = try await client.execute(
+        uri: "/users/\(participant.userID)/participating_events",
+        method: .get,
+        headers: [
+          .cfConnectingIP: ipAddress
+        ]
+      )
+      #expect(unauthenticatedResponse.status == .unauthorized)
+    }
+  }
+
+  @Test
   func createAndGetUsers() async throws {
     let arguments = TestArguments()
     let app = try await buildApplication(arguments)

--- a/public/documents/openapi.yml
+++ b/public/documents/openapi.yml
@@ -227,6 +227,58 @@ paths:
           description: Not Authorization
         '404':
           description: Not found User Profile
+  /users/{user_id}/organized_events:
+    get:
+      operationId: getUserOrganizedEvents
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: user_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: User id.
+      responses:
+        '200':
+          description: A success response with events organized by the user.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Event'
+        '400':
+          description: A bad request
+        '401':
+          description: Not Authorization
+  /users/{user_id}/participating_events:
+    get:
+      operationId: getUserParticipatingEvents
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: user_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: User id.
+      responses:
+        '200':
+          description: A success response with events the user participates in.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Event'
+        '400':
+          description: A bad request
+        '401':
+          description: Not Authorization
   /images/upload_url:
     post:
       operationId: createImageUploadURL


### PR DESCRIPTION
Closes #180

## Summary
- add GET /users/{user_id}/organized_events
- add GET /users/{user_id}/participating_events
- return private/unpublished/canceled organized events only to the owner, and public published uncanceled events to other users
- return active participating events to the owner, and public published uncanceled participating events to other users