### PR TITLE
Restrict direct Cloud Run ingress by default

### DIFF
--- a/Terraform/README.md
+++ b/Terraform/README.md
@@ -158,7 +158,11 @@ Cloud Run service, OTel Collector sidecar, WIF pool/provider, deployer SA, IAM b
 
 ### 10.5. `api.blindlog.me` の二段階 rollout
 
-初回は `restrict_direct_cloud_run_ingress = false` のまま apply し、Load Balancer / Cloud Armor / Certificate Manager / Cloudflare DNS を作る。既存の `api.blindlog.me` DNS record が Cloudflare にある場合は、先に削除するか Terraform に import してから apply する。
+`restrict_direct_cloud_run_ingress` はデフォルトで `true` になっており、Cloud Run の `*.run.app` 直アクセスを拒否する。初回 bootstrap では Load Balancer / Cloud Armor / Certificate Manager / Cloudflare DNS を作るため、`terraform.tfvars` に以下を一時的に追加して apply する。既存の `api.blindlog.me` DNS record が Cloudflare にある場合は、先に削除するか Terraform に import してから apply する。
+
+```hcl
+restrict_direct_cloud_run_ingress = false
+```
 
 ```sh
 terraform apply
@@ -167,11 +171,7 @@ terraform output -raw api_health_url
 
 Certificate Manager の証明書と certificate map entry が `ACTIVE` になり、`https://api.blindlog.me/health` が 200 を返すまで待つ。証明書発行には数分から 1 時間程度かかる場合がある。
 
-疎通確認後、`terraform.tfvars` で以下を有効化して再 apply する。
-
-```hcl
-restrict_direct_cloud_run_ingress = true
-```
+疎通確認後、`terraform.tfvars` から `restrict_direct_cloud_run_ingress = false` を削除して再 apply する。`allow_unauthenticated = true` と `restrict_direct_cloud_run_ingress = false` を常用すると、Cloudflare / Cloud Armor を通らない direct access で `CF-Connecting-IP` を信頼できなくなるため、bootstrap 後は必ず direct ingress を制限する。
 
 ```sh
 terraform apply

--- a/Terraform/terraform.tfvars.example
+++ b/Terraform/terraform.tfvars.example
@@ -22,7 +22,9 @@ cloudflare_zone_id = "0123456789abcdef0123456789abcdef"
 # otel_collector_image            = "us-docker.pkg.dev/cloud-ops-agents-artifacts/google-cloud-opentelemetry-collector/otelcol-google:0.144.0"
 # otel_collector_memory           = "256Mi"
 # allow_unauthenticated = true
-# restrict_direct_cloud_run_ingress = false # Set to true after api_hostname works through the load balancer.
+# Default true blocks direct public *.run.app access. Set this to false only
+# during initial load balancer / certificate bootstrap, then remove the override.
+# restrict_direct_cloud_run_ingress = true
 
 # First `terraform apply` uses this tag. After that, GitHub Actions overrides
 # the running image with `gcloud run services update --image=...:<sha>`, and

--- a/Terraform/variables.tf
+++ b/Terraform/variables.tf
@@ -153,7 +153,7 @@ variable "region" {
 variable "restrict_direct_cloud_run_ingress" {
   description = "When true, allow external traffic only through Google Cloud Load Balancing and block direct public run.app access."
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "service_name" {


### PR DESCRIPTION
## Summary
- Change `restrict_direct_cloud_run_ingress` default to `true` so direct public `*.run.app` access is blocked by default.
- Update the Terraform bootstrap docs to use a temporary explicit `false` override only during load balancer / certificate setup.
- Update `terraform.tfvars.example` to document the safer default and bootstrap-only override.

Closes #195