### PR TITLE
Validate Cloud Run instance count bounds

### DIFF
--- a/Terraform/variables.tf
+++ b/Terraform/variables.tf
@@ -81,6 +81,11 @@ variable "max_instance_count" {
     condition     = var.max_instance_count >= 1
     error_message = "max_instance_count must be at least 1."
   }
+
+  validation {
+    condition     = var.min_instance_count <= var.max_instance_count
+    error_message = "max_instance_count must be greater than or equal to min_instance_count."
+  }
 }
 
 variable "memory" {


### PR DESCRIPTION
## Summary
- Add Terraform validation that `min_instance_count` must not exceed `max_instance_count`.
- Keep the existing individual lower-bound checks unchanged.

Closes #224