### PR TITLE
Ignore local secrets in Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,27 @@
 .build
 .git
+.swiftpm
+.devContainer
+Packages
+*.xcodeproj
+xcuserdata
+.vscode
+.env
+.env.*
+DerivedData
+
+# Terraform local state/config
+**/.terraform
+**/.terraform/**
+**/terraform.tfvars
+**/*.tfvars
+**/*.tfstate
+**/*.tfstate.*
+
+# Local tooling and editor state
+.agents
+.claude
+.DS_Store
+**/.DS_Store
+.derived-data-log-*
+dump.rdb


### PR DESCRIPTION
## Summary
- Expand `.dockerignore` so local secrets, Terraform state/config, editor state, and caches are not sent to the Docker build context.
- Keep the change scoped to Docker build context ignores.

## Tests
- git diff --check

Closes #222