### PR TITLE
Consume auth challenges atomically

### DIFF
--- a/Sources/App/API/GetTokenFromEmail.swift
+++ b/Sources/App/API/GetTokenFromEmail.swift
@@ -30,7 +30,7 @@ extension API {
       let challengeData = try Data(bodyData.challenge.base64decoded())
       let key = ValkeyKey("OTPEmailAuthentication:\(challengeData.base64EncodedString())")
 
-      let data = try await cache.get(key)
+      let data = try await cache.getdel(key)
       let challenge = try data.map {
         try JSONDecoder().decode(OTPEmailAuthentication.self, from: Data($0))
       }
@@ -55,13 +55,12 @@ extension API {
         return .unauthorized
       }
 
-      try await cache.del(keys: [key])
     } catch {
       AppRequestContext.current?.logger.appError(
         eventName: "auth.email.challenge.verify_failed",
         "Failed to verify and delete authentication challenge",
         metadata: [
-          "cache.operation": .string("get_delete"),
+          "cache.operation": .string("getdel"),
           "auth.flow": .string("email_token"),
         ],
         error: error

--- a/Sources/App/API/GetTokenFromPasskey.swift
+++ b/Sources/App/API/GetTokenFromPasskey.swift
@@ -45,7 +45,7 @@ extension API {
       let challengeData = try Data(bodyData.challenge.base64decoded())
       let key = ValkeyKey("challenge:\(challengeData.base64EncodedString())")
 
-      let data = try await cache.get(key)
+      let data = try await cache.getdel(key)
       let challenge = try data.map { try JSONDecoder().decode(Challenge.self, from: Data($0)) }
 
       guard let challenge else {
@@ -56,14 +56,13 @@ extension API {
         return .badRequest
       }
 
-      try await cache.del(keys: [key])
     } catch {
       AppRequestContext.current?.logger.appError(
         eventName: "auth.passkey.challenge.verify_failed",
         "Failed to verify and delete authentication challenge",
         metadata: [
           "auth.flow": .string("passkey"),
-          "cache.operation": .string("get_delete"),
+          "cache.operation": .string("getdel"),
         ],
         error: error
       )

--- a/Sources/App/API/Passkey.swift
+++ b/Sources/App/API/Passkey.swift
@@ -42,7 +42,7 @@ extension API {
     do {
       let key = ValkeyKey("challenge:\(challengeData.base64EncodedString())")
 
-      let data = try await cache.get(key)
+      let data = try await cache.getdel(key)
       let challenge = try data.map { try JSONDecoder().decode(Challenge.self, from: Data($0)) }
 
       guard let challenge else {
@@ -53,13 +53,12 @@ extension API {
         return .badRequest
       }
 
-      try await cache.del(keys: [key])
     } catch {
       AppRequestContext.current?.logger.appError(
         eventName: "auth.passkey.registration_challenge_verify_failed",
         "Failed to verify and delete registration challenge",
         metadata: AppLogMetadata.userID(userID).merging([
-          "cache.operation": .string("get_delete")
+          "cache.operation": .string("getdel")
         ]) { _, new in new },
         error: error
       )


### PR DESCRIPTION
## Summary
- Use Valkey GETDEL when consuming passkey registration challenges.
- Use Valkey GETDEL when consuming passkey authentication challenges.
- Use Valkey GETDEL when consuming email login OTP challenges.

## Tests
- swift build
- git diff --check

Closes #185
Closes #188