### PR TITLE
Reject duplicate wine variety IDs

### DIFF
--- a/Sources/App/API/Events.swift
+++ b/Sources/App/API/Events.swift
@@ -1216,7 +1216,10 @@ extension API {
 
   fileprivate func parseUUIDs(_ strings: [String]) -> [UUID]? {
     let ids = strings.compactMap(UUID.init(uuidString:))
-    return ids.count == strings.count ? ids : nil
+    guard ids.count == strings.count, Set(ids).count == ids.count else {
+      return nil
+    }
+    return ids
   }
 
   fileprivate func trimmedOptional(_ string: String?) -> String? {

--- a/public/documents/openapi.yml
+++ b/public/documents/openapi.yml
@@ -1279,6 +1279,7 @@ components:
           maximum: 100
         wineVarietyIDs:
           type: array
+          uniqueItems: true
           items:
             type: string
             format: uuid
@@ -1310,6 +1311,7 @@ components:
           maximum: 100
         wineVarietyIDs:
           type: array
+          uniqueItems: true
           items:
             type: string
             format: uuid
@@ -1343,6 +1345,7 @@ components:
           type: string
         wineVarietyIDs:
           type: array
+          uniqueItems: true
           items:
             type: string
             format: uuid
@@ -1379,6 +1382,7 @@ components:
           type: string
         wineVarietyIDs:
           type: array
+          uniqueItems: true
           items:
             type: string
             format: uuid


### PR DESCRIPTION
## Summary
- Reject duplicate `wineVarietyIDs` during UUID parsing for correct answers and responses.
- Mark event answer/response `wineVarietyIDs` schemas as `uniqueItems` in OpenAPI.

## Tests
- swift build
- git diff --check

Closes #184