### PR TITLE
Validate event question vintage values

### DIFF
--- a/Sources/App/API/Events.swift
+++ b/Sources/App/API/Events.swift
@@ -400,7 +400,10 @@ extension API {
     }
     let (styleID, validStyleID) = parseOptionalUUID(body.wineStyleID)
     let (regionID, validRegionID) = parseOptionalUUID(body.wineRegionID)
-    guard validStyleID, validRegionID, isValidAlcoholByVolume(body.alcoholByVolume) else {
+    guard
+      validStyleID, validRegionID, isValidVintage(body.vintage),
+      isValidAlcoholByVolume(body.alcoholByVolume)
+    else {
       return .badRequest
     }
 
@@ -449,7 +452,10 @@ extension API {
     }
     let (styleID, validStyleID) = parseOptionalUUID(body.wineStyleID)
     let (regionID, validRegionID) = parseOptionalUUID(body.wineRegionID)
-    guard validStyleID, validRegionID, isValidAlcoholByVolume(body.alcoholByVolume) else {
+    guard
+      validStyleID, validRegionID, isValidVintage(body.vintage),
+      isValidAlcoholByVolume(body.alcoholByVolume)
+    else {
       return .badRequest
     }
 
@@ -496,7 +502,10 @@ extension API {
     }
     let (styleID, validStyleID) = parseOptionalUUID(body.wineStyleID)
     let (regionID, validRegionID) = parseOptionalUUID(body.wineRegionID)
-    guard validStyleID, validRegionID, isValidAlcoholByVolume(body.alcoholByVolume) else {
+    guard
+      validStyleID, validRegionID, isValidVintage(body.vintage),
+      isValidAlcoholByVolume(body.alcoholByVolume)
+    else {
       return .badRequest
     }
 
@@ -547,7 +556,10 @@ extension API {
     }
     let (styleID, validStyleID) = parseOptionalUUID(body.wineStyleID)
     let (regionID, validRegionID) = parseOptionalUUID(body.wineRegionID)
-    guard validStyleID, validRegionID, isValidAlcoholByVolume(body.alcoholByVolume) else {
+    guard
+      validStyleID, validRegionID, isValidVintage(body.vintage),
+      isValidAlcoholByVolume(body.alcoholByVolume)
+    else {
       return .badRequest
     }
 
@@ -1230,6 +1242,11 @@ extension API {
   fileprivate func isValidAlcoholByVolume(_ alcoholByVolume: Double?) -> Bool {
     guard let alcoholByVolume else { return true }
     return alcoholByVolume >= 0 && alcoholByVolume <= 100
+  }
+
+  fileprivate func isValidVintage(_ vintage: Int32?) -> Bool {
+    guard let vintage else { return true }
+    return vintage > 0
   }
 
   fileprivate func logEventDatabaseError(

--- a/public/documents/openapi.yml
+++ b/public/documents/openapi.yml
@@ -1272,6 +1272,7 @@ components:
         vintage:
           type: integer
           format: int32
+          minimum: 1
         alcoholByVolume:
           type: number
           format: double
@@ -1303,6 +1304,7 @@ components:
         vintage:
           type: integer
           format: int32
+          minimum: 1
         alcoholByVolume:
           type: number
           format: double
@@ -1334,6 +1336,7 @@ components:
         vintage:
           type: integer
           format: int32
+          minimum: 1
         alcoholByVolume:
           type: number
           format: double
@@ -1370,6 +1373,7 @@ components:
         vintage:
           type: integer
           format: int32
+          minimum: 1
         alcoholByVolume:
           type: number
           format: double


### PR DESCRIPTION
## Summary
- Reject non-positive `vintage` values for event correct answers and responses.
- Add `minimum: 1` to the matching OpenAPI schemas.

## Tests
- swift build
- git diff --check

Closes #197