### PR TITLE
Fallback when profile image URL fetch fails

### DIFF
--- a/Sources/App/API/UserProfile.swift
+++ b/Sources/App/API/UserProfile.swift
@@ -266,7 +266,21 @@ extension API {
   ) async throws -> Components.Schemas.UserProfile {
     let imageURL: String?
     if let cloudflareImageID = profile.cloudflareImageID {
-      imageURL = try await profileImageURL(cloudflareImageID: cloudflareImageID, userID: userID)
+      do {
+        imageURL = try await profileImageURL(cloudflareImageID: cloudflareImageID, userID: userID)
+      } catch {
+        AppRequestContext.current?.logger.appLog(
+          level: .warning,
+          eventName: "user.profile_image_url_read_failed",
+          "Failed to fetch user profile image URL",
+          metadata: AppLogMetadata.userID(userID).merging([
+            "cloudflare.operation": .string("images.image"),
+            "image.id": .string(cloudflareImageID),
+          ]) { _, new in new },
+          error: error
+        )
+        imageURL = nil
+      }
     } else {
       imageURL = nil
     }


### PR DESCRIPTION
## Summary
- Return profile responses with `imageURL: nil` when Cloudflare image URL resolution fails.
- Log the image URL failure as a warning instead of turning a persisted profile create/read into `400`.

## Tests
- swift build
- git diff --check

Closes #219