### PR TITLE
Align CI Swift version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
-    container: swift:6.3.1-noble
+    container: swift:6.3.2-noble
     steps:
       - uses: actions/checkout@v6.0.2
       - run: swift format lint -r -p -s .


### PR DESCRIPTION
## Summary
- Update the CI Swift container from `swift:6.3.1-noble` to `swift:6.3.2-noble`.
- Keep the CI cache key, Dockerfile, and compose Swift version aligned at 6.3.2.

## Tests
- rg -n "swift:6\.3\.[^2]|swift-6\.3\.[^2]" .github Dockerfile compose.yml README.md
- git diff --check

Closes #199