### PR TITLE
Seed wine master data in local Postgres

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -13,6 +13,7 @@ services:
     volumes:
       - ./Database/extensions.sql:/docker-entrypoint-initdb.d/001_extensions.sql:ro
       - ./Database/schema.sql:/docker-entrypoint-initdb.d/002_schema.sql:ro
+      - ./Database/migrations/20260531060000_seed_wine_master_data.sql:/docker-entrypoint-initdb.d/003_seed_wine_master_data.sql:ro
 
   otel-collector:
     image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.144.0


### PR DESCRIPTION
## Summary
- Add the wine master seed migration to the local/CI Postgres init scripts in `compose.yml`.
- Keep extensions and schema initialization order unchanged, then load wine master data.

## Tests
- docker compose config
- git diff --check

Closes #203