### PR TITLE
Enforce image ownership in database

### DIFF
--- a/Database/migrations/20260602173000_enforce_image_ownership.sql
+++ b/Database/migrations/20260602173000_enforce_image_ownership.sql
@@ -44,7 +44,7 @@ ALTER TABLE public.user_profiles
   REFERENCES public.images (id, user_id)
   ON DELETE RESTRICT;
 
-CREATE FUNCTION public.enforce_event_revision_image_owner()
+CREATE OR REPLACE FUNCTION public.enforce_event_revision_image_owner()
 RETURNS trigger
 LANGUAGE plpgsql
 AS $$
@@ -75,12 +75,14 @@ BEGIN
 END;
 $$;
 
+DROP TRIGGER IF EXISTS event_revisions_image_owner_trg ON public.event_revisions;
+
 CREATE TRIGGER event_revisions_image_owner_trg
 BEFORE INSERT OR UPDATE OF event_id, image_id ON public.event_revisions
 FOR EACH ROW
 EXECUTE FUNCTION public.enforce_event_revision_image_owner();
 
-CREATE FUNCTION public.enforce_event_question_revision_image_owner()
+CREATE OR REPLACE FUNCTION public.enforce_event_question_revision_image_owner()
 RETURNS trigger
 LANGUAGE plpgsql
 AS $$
@@ -111,6 +113,8 @@ BEGIN
   RETURN NEW;
 END;
 $$;
+
+DROP TRIGGER IF EXISTS event_question_revisions_image_owner_trg ON public.event_question_revisions;
 
 CREATE TRIGGER event_question_revisions_image_owner_trg
 BEFORE INSERT OR UPDATE OF event_question_id, image_id ON public.event_question_revisions

--- a/Database/migrations/20260602173000_enforce_image_ownership.sql
+++ b/Database/migrations/20260602173000_enforce_image_ownership.sql
@@ -1,0 +1,118 @@
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM public.user_profiles p
+    JOIN public.images i ON i.id = p.image_id
+    WHERE p.image_id IS NOT NULL
+      AND i.user_id <> p.user_id
+  ) THEN
+    RAISE EXCEPTION 'user_profiles contains image references owned by another user';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM public.event_revisions r
+    JOIN public.events e ON e.id = r.event_id
+    JOIN public.images i ON i.id = r.image_id
+    WHERE r.image_id IS NOT NULL
+      AND i.user_id <> e.organizer_user_id
+  ) THEN
+    RAISE EXCEPTION 'event_revisions contains image references not owned by the organizer';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM public.event_question_revisions r
+    JOIN public.event_questions q ON q.id = r.event_question_id
+    JOIN public.events e ON e.id = q.event_id
+    JOIN public.images i ON i.id = r.image_id
+    WHERE r.image_id IS NOT NULL
+      AND i.user_id <> e.organizer_user_id
+  ) THEN
+    RAISE EXCEPTION 'event_question_revisions contains image references not owned by the organizer';
+  END IF;
+END;
+$$;
+
+ALTER TABLE public.images
+  ADD CONSTRAINT images_id_user_id_key UNIQUE (id, user_id);
+
+ALTER TABLE public.user_profiles
+  ADD CONSTRAINT user_profiles_image_owner_fk
+  FOREIGN KEY (image_id, user_id)
+  REFERENCES public.images (id, user_id)
+  ON DELETE RESTRICT;
+
+CREATE FUNCTION public.enforce_event_revision_image_owner()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  image_owner_id uuid;
+  organizer_user_id uuid;
+BEGIN
+  IF NEW.image_id IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT user_id INTO image_owner_id
+  FROM public.images
+  WHERE id = NEW.image_id;
+
+  SELECT organizer_user_id INTO organizer_user_id
+  FROM public.events
+  WHERE id = NEW.event_id;
+
+  IF image_owner_id IS NOT NULL
+    AND organizer_user_id IS NOT NULL
+    AND image_owner_id <> organizer_user_id THEN
+    RAISE EXCEPTION 'event revision image must be owned by the event organizer'
+      USING ERRCODE = '23503';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER event_revisions_image_owner_trg
+BEFORE INSERT OR UPDATE OF event_id, image_id ON public.event_revisions
+FOR EACH ROW
+EXECUTE FUNCTION public.enforce_event_revision_image_owner();
+
+CREATE FUNCTION public.enforce_event_question_revision_image_owner()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  image_owner_id uuid;
+  organizer_user_id uuid;
+BEGIN
+  IF NEW.image_id IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT user_id INTO image_owner_id
+  FROM public.images
+  WHERE id = NEW.image_id;
+
+  SELECT e.organizer_user_id INTO organizer_user_id
+  FROM public.event_questions q
+  JOIN public.events e ON e.id = q.event_id
+  WHERE q.id = NEW.event_question_id;
+
+  IF image_owner_id IS NOT NULL
+    AND organizer_user_id IS NOT NULL
+    AND image_owner_id <> organizer_user_id THEN
+    RAISE EXCEPTION 'event question revision image must be owned by the event organizer'
+      USING ERRCODE = '23503';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER event_question_revisions_image_owner_trg
+BEFORE INSERT OR UPDATE OF event_question_id, image_id ON public.event_question_revisions
+FOR EACH ROW
+EXECUTE FUNCTION public.enforce_event_question_revision_image_owner();

--- a/Database/migrations/atlas.sum
+++ b/Database/migrations/atlas.sum
@@ -1,5 +1,5 @@
-h1:qJtO+kyvNOzoEaWfd+7FaOr3oZnfQFp2iAvdAoPSI0g=
+h1:dsvwHtmyxX5uX4+oEFNHbwXZQO2Cz9dyCBM/16ka3w4=
 000001_initial_schema.sql h1:iQH63d3ckYBCOcFnKf6nkOsitlGdpumeDPFZMcnCuz4=
 20260531034124_events.sql h1:PedeyzF85utC/LHxKCc9z5Gs8puDptsTNkRapWNKjrI=
 20260531060000_seed_wine_master_data.sql h1:54BEUlfrgkN/2W4aM32RYFg5x74O9IeSS/lR0v04t7g=
-20260602173000_enforce_image_ownership.sql h1:qyyywtLUA8+K5F1CffB69ZSTqKG0NTYnk4CB2k8Ttq4=
+20260602173000_enforce_image_ownership.sql h1:iQfPJ6KdGD0DPlghaoVsVUWURyApnIj76JL1iB1rmcc=

--- a/Database/migrations/atlas.sum
+++ b/Database/migrations/atlas.sum
@@ -1,4 +1,5 @@
-h1:L4Vso8DX66cVYUP8GG1kZ3/Pt5oXqX41Xh5J1jGSn3w=
+h1:qJtO+kyvNOzoEaWfd+7FaOr3oZnfQFp2iAvdAoPSI0g=
 000001_initial_schema.sql h1:iQH63d3ckYBCOcFnKf6nkOsitlGdpumeDPFZMcnCuz4=
 20260531034124_events.sql h1:PedeyzF85utC/LHxKCc9z5Gs8puDptsTNkRapWNKjrI=
 20260531060000_seed_wine_master_data.sql h1:54BEUlfrgkN/2W4aM32RYFg5x74O9IeSS/lR0v04t7g=
+20260602173000_enforce_image_ownership.sql h1:qyyywtLUA8+K5F1CffB69ZSTqKG0NTYnk4CB2k8Ttq4=

--- a/Database/schema.sql
+++ b/Database/schema.sql
@@ -43,6 +43,7 @@ CREATE TABLE public.images (
   created_at timestamptz NOT NULL DEFAULT now(),
   CONSTRAINT images_pk PRIMARY KEY (id),
   CONSTRAINT images_user_fk FOREIGN KEY (user_id) REFERENCES public.users (id) ON DELETE RESTRICT,
+  CONSTRAINT images_id_user_id_key UNIQUE (id, user_id),
   CONSTRAINT images_cloudflare_image_id_key UNIQUE (cloudflare_image_id)
 );
 
@@ -57,6 +58,7 @@ CREATE TABLE public.user_profiles (
   CONSTRAINT user_profiles_pk PRIMARY KEY (id),
   CONSTRAINT user_profiles_user_fk FOREIGN KEY (user_id) REFERENCES public.users (id) ON DELETE RESTRICT,
   CONSTRAINT user_profiles_image_fk FOREIGN KEY (image_id) REFERENCES public.images (id) ON DELETE RESTRICT,
+  CONSTRAINT user_profiles_image_owner_fk FOREIGN KEY (image_id, user_id) REFERENCES public.images (id, user_id) ON DELETE RESTRICT,
   CONSTRAINT user_profiles_name_length CHECK (char_length(trim(name)) BETWEEN 1 AND 100)
 );
 
@@ -171,6 +173,79 @@ CREATE TABLE public.event_question_revisions (
 
 CREATE INDEX event_question_revisions_event_question_latest_idx ON public.event_question_revisions(event_question_id, created_at DESC, id DESC);
 CREATE INDEX event_question_revisions_image_id_idx ON public.event_question_revisions(image_id);
+
+CREATE FUNCTION public.enforce_event_revision_image_owner()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  image_owner_id uuid;
+  organizer_user_id uuid;
+BEGIN
+  IF NEW.image_id IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT user_id INTO image_owner_id
+  FROM public.images
+  WHERE id = NEW.image_id;
+
+  SELECT organizer_user_id INTO organizer_user_id
+  FROM public.events
+  WHERE id = NEW.event_id;
+
+  IF image_owner_id IS NOT NULL
+    AND organizer_user_id IS NOT NULL
+    AND image_owner_id <> organizer_user_id THEN
+    RAISE EXCEPTION 'event revision image must be owned by the event organizer'
+      USING ERRCODE = '23503';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER event_revisions_image_owner_trg
+BEFORE INSERT OR UPDATE OF event_id, image_id ON public.event_revisions
+FOR EACH ROW
+EXECUTE FUNCTION public.enforce_event_revision_image_owner();
+
+CREATE FUNCTION public.enforce_event_question_revision_image_owner()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  image_owner_id uuid;
+  organizer_user_id uuid;
+BEGIN
+  IF NEW.image_id IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT user_id INTO image_owner_id
+  FROM public.images
+  WHERE id = NEW.image_id;
+
+  SELECT e.organizer_user_id INTO organizer_user_id
+  FROM public.event_questions q
+  JOIN public.events e ON e.id = q.event_id
+  WHERE q.id = NEW.event_question_id;
+
+  IF image_owner_id IS NOT NULL
+    AND organizer_user_id IS NOT NULL
+    AND image_owner_id <> organizer_user_id THEN
+    RAISE EXCEPTION 'event question revision image must be owned by the event organizer'
+      USING ERRCODE = '23503';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER event_question_revisions_image_owner_trg
+BEFORE INSERT OR UPDATE OF event_question_id, image_id ON public.event_question_revisions
+FOR EACH ROW
+EXECUTE FUNCTION public.enforce_event_question_revision_image_owner();
 
 CREATE TABLE public.wine_styles (
   id uuid NOT NULL,


### PR DESCRIPTION
## Summary
- Add `images(id, user_id)` uniqueness and a composite `user_profiles(image_id, user_id)` foreign key.
- Add triggers that reject event and event-question revision images not owned by the event organizer.
- Add migration preflight checks so existing cross-user image references fail explicitly before constraints/triggers are installed.
- Update Atlas migration checksums.

## Tests
- atlas migrate hash --dir file://Database/migrations
- atlas migrate validate --dir file://Database/migrations
- swift build
- git diff --check

Closes #208