### PR TITLE
Remove wine style from tasting answers

### DIFF
--- a/Database/migrations/20260603120000_remove_answer_wine_style_id.sql
+++ b/Database/migrations/20260603120000_remove_answer_wine_style_id.sql
@@ -1,0 +1,10 @@
+DROP INDEX IF EXISTS public.event_question_correct_answer_revisions_wine_style_id_idx;
+DROP INDEX IF EXISTS public.event_question_response_revisions_wine_style_id_idx;
+
+ALTER TABLE public.event_question_correct_answer_revisions
+  DROP CONSTRAINT IF EXISTS event_question_correct_answer_revisions_wine_style_fk,
+  DROP COLUMN IF EXISTS wine_style_id;
+
+ALTER TABLE public.event_question_response_revisions
+  DROP CONSTRAINT IF EXISTS event_question_response_revisions_wine_style_fk,
+  DROP COLUMN IF EXISTS wine_style_id;

--- a/Database/migrations/atlas.sum
+++ b/Database/migrations/atlas.sum
@@ -1,5 +1,6 @@
-h1:/UYG1xgt8p2cIacvP9vQ8JDozlQt9sZTvJT5Z3TaLX0=
+h1:fhiGHkKGE9niMd08x5S6tJhkTh0/DsENiSD1L1owPXg=
 000001_initial_schema.sql h1:iQH63d3ckYBCOcFnKf6nkOsitlGdpumeDPFZMcnCuz4=
 20260531034124_events.sql h1:PedeyzF85utC/LHxKCc9z5Gs8puDptsTNkRapWNKjrI=
 20260531060000_seed_wine_master_data.sql h1:54BEUlfrgkN/2W4aM32RYFg5x74O9IeSS/lR0v04t7g=
 20260602180000_event_entry_fee_minor_amount_bigint.sql h1:Nskgodx2WNgictwuGJMAYs/Pli0emUuICLoU1ho6q/A=
+20260603120000_remove_answer_wine_style_id.sql h1:rD0HPVkxOK6bueWprhfrpD0no9c3hvP/+OvEKOEGNic=

--- a/Database/schema.sql
+++ b/Database/schema.sql
@@ -237,21 +237,18 @@ CREATE UNIQUE INDEX wine_regions_root_name_key ON public.wine_regions(name) WHER
 CREATE TABLE public.event_question_correct_answer_revisions (
   id uuid NOT NULL,
   event_question_id uuid NOT NULL,
-  wine_style_id uuid,
   wine_region_id uuid,
   vintage integer,
   alcohol_by_volume numeric(5,2),
   created_at timestamptz NOT NULL DEFAULT now(),
   CONSTRAINT event_question_correct_answer_revisions_pk PRIMARY KEY (id),
   CONSTRAINT event_question_correct_answer_revisions_event_question_fk FOREIGN KEY (event_question_id) REFERENCES public.event_questions (id) ON DELETE RESTRICT,
-  CONSTRAINT event_question_correct_answer_revisions_wine_style_fk FOREIGN KEY (wine_style_id) REFERENCES public.wine_styles (id) ON DELETE RESTRICT,
   CONSTRAINT event_question_correct_answer_revisions_wine_region_fk FOREIGN KEY (wine_region_id) REFERENCES public.wine_regions (id) ON DELETE RESTRICT,
   CONSTRAINT event_question_correct_answer_revisions_vintage_positive CHECK (vintage IS NULL OR vintage > 0),
   CONSTRAINT event_question_correct_answer_revisions_alcohol_by_volume_range CHECK (alcohol_by_volume IS NULL OR (alcohol_by_volume >= 0 AND alcohol_by_volume <= 100))
 );
 
 CREATE INDEX event_question_correct_answer_revisions_event_question_latest_idx ON public.event_question_correct_answer_revisions(event_question_id, created_at DESC, id DESC);
-CREATE INDEX event_question_correct_answer_revisions_wine_style_id_idx ON public.event_question_correct_answer_revisions(wine_style_id);
 CREATE INDEX event_question_correct_answer_revisions_wine_region_id_idx ON public.event_question_correct_answer_revisions(wine_region_id);
 
 CREATE TABLE public.event_question_correct_answer_revision_varieties (
@@ -269,7 +266,6 @@ CREATE TABLE public.event_question_response_revisions (
   id uuid NOT NULL,
   event_question_id uuid NOT NULL,
   user_id uuid NOT NULL,
-  wine_style_id uuid,
   wine_region_id uuid,
   vintage integer,
   alcohol_by_volume numeric(5,2),
@@ -278,7 +274,6 @@ CREATE TABLE public.event_question_response_revisions (
   CONSTRAINT event_question_response_revisions_pk PRIMARY KEY (id),
   CONSTRAINT event_question_response_revisions_event_question_fk FOREIGN KEY (event_question_id) REFERENCES public.event_questions (id) ON DELETE RESTRICT,
   CONSTRAINT event_question_response_revisions_user_fk FOREIGN KEY (user_id) REFERENCES public.users (id) ON DELETE RESTRICT,
-  CONSTRAINT event_question_response_revisions_wine_style_fk FOREIGN KEY (wine_style_id) REFERENCES public.wine_styles (id) ON DELETE RESTRICT,
   CONSTRAINT event_question_response_revisions_wine_region_fk FOREIGN KEY (wine_region_id) REFERENCES public.wine_regions (id) ON DELETE RESTRICT,
   CONSTRAINT event_question_response_revisions_vintage_positive CHECK (vintage IS NULL OR vintage > 0),
   CONSTRAINT event_question_response_revisions_alcohol_by_volume_range CHECK (alcohol_by_volume IS NULL OR (alcohol_by_volume >= 0 AND alcohol_by_volume <= 100))
@@ -286,7 +281,6 @@ CREATE TABLE public.event_question_response_revisions (
 
 CREATE INDEX event_question_response_revisions_event_question_user_latest_idx ON public.event_question_response_revisions(event_question_id, user_id, submitted_at DESC, id DESC);
 CREATE INDEX event_question_response_revisions_user_id_idx ON public.event_question_response_revisions(user_id);
-CREATE INDEX event_question_response_revisions_wine_style_id_idx ON public.event_question_response_revisions(wine_style_id);
 CREATE INDEX event_question_response_revisions_wine_region_id_idx ON public.event_question_response_revisions(wine_region_id);
 
 CREATE TABLE public.event_question_response_revision_varieties (

--- a/Sources/App/API/Events.swift
+++ b/Sources/App/API/Events.swift
@@ -398,10 +398,9 @@ extension API {
     else {
       return .badRequest
     }
-    let (styleID, validStyleID) = parseOptionalUUID(body.wineStyleID)
     let (regionID, validRegionID) = parseOptionalUUID(body.wineRegionID)
     guard
-      validStyleID, validRegionID, isValidVintage(body.vintage),
+      validRegionID, isValidVintage(body.vintage),
       isValidAlcoholByVolume(body.alcoholByVolume)
     else {
       return .badRequest
@@ -415,7 +414,6 @@ extension API {
       }
       let answer = try await insertCorrectAnswer(
         questionID: questionID,
-        styleID: styleID,
         regionID: regionID,
         vintage: body.vintage.map(Int.init),
         alcoholByVolume: body.alcoholByVolume,
@@ -450,10 +448,9 @@ extension API {
     else {
       return .badRequest
     }
-    let (styleID, validStyleID) = parseOptionalUUID(body.wineStyleID)
     let (regionID, validRegionID) = parseOptionalUUID(body.wineRegionID)
     guard
-      validStyleID, validRegionID, isValidVintage(body.vintage),
+      validRegionID, isValidVintage(body.vintage),
       isValidAlcoholByVolume(body.alcoholByVolume)
     else {
       return .badRequest
@@ -468,7 +465,6 @@ extension API {
 
       let answer = try await insertCorrectAnswer(
         questionID: questionID,
-        styleID: styleID,
         regionID: regionID,
         vintage: body.vintage.map(Int.init),
         alcoholByVolume: body.alcoholByVolume,
@@ -500,10 +496,9 @@ extension API {
     else {
       return .badRequest
     }
-    let (styleID, validStyleID) = parseOptionalUUID(body.wineStyleID)
     let (regionID, validRegionID) = parseOptionalUUID(body.wineRegionID)
     guard
-      validStyleID, validRegionID, isValidVintage(body.vintage),
+      validRegionID, isValidVintage(body.vintage),
       isValidAlcoholByVolume(body.alcoholByVolume)
     else {
       return .badRequest
@@ -518,7 +513,6 @@ extension API {
       let response = try await insertQuestionResponse(
         questionID: questionID,
         userID: userID,
-        styleID: styleID,
         regionID: regionID,
         vintage: body.vintage.map(Int.init),
         alcoholByVolume: body.alcoholByVolume,
@@ -554,10 +548,9 @@ extension API {
     else {
       return .badRequest
     }
-    let (styleID, validStyleID) = parseOptionalUUID(body.wineStyleID)
     let (regionID, validRegionID) = parseOptionalUUID(body.wineRegionID)
     guard
-      validStyleID, validRegionID, isValidVintage(body.vintage),
+      validRegionID, isValidVintage(body.vintage),
       isValidAlcoholByVolume(body.alcoholByVolume)
     else {
       return .badRequest
@@ -573,7 +566,6 @@ extension API {
       let response = try await insertQuestionResponse(
         questionID: questionID,
         userID: userID,
-        styleID: styleID,
         regionID: regionID,
         vintage: body.vintage.map(Int.init),
         alcoholByVolume: body.alcoholByVolume,
@@ -1155,7 +1147,6 @@ extension API {
 
   fileprivate func insertCorrectAnswer(
     questionID: UUID,
-    styleID: UUID?,
     regionID: UUID?,
     vintage: Int?,
     alcoholByVolume: Double?,
@@ -1165,7 +1156,6 @@ extension API {
     let answer = EventQuestionCorrectAnswerRecord(
       id: UUID(uuidString: UUID.uuidV7String())!,
       eventQuestionID: questionID,
-      wineStyleID: styleID,
       wineRegionID: regionID,
       vintage: vintage,
       alcoholByVolume: alcoholByVolume,
@@ -1197,7 +1187,6 @@ extension API {
   fileprivate func insertQuestionResponse(
     questionID: UUID,
     userID: UUID,
-    styleID: UUID?,
     regionID: UUID?,
     vintage: Int?,
     alcoholByVolume: Double?,
@@ -1209,7 +1198,6 @@ extension API {
       id: UUID(uuidString: UUID.uuidV7String())!,
       eventQuestionID: questionID,
       userID: userID,
-      wineStyleID: styleID,
       wineRegionID: regionID,
       vintage: vintage,
       alcoholByVolume: alcoholByVolume,
@@ -1385,7 +1373,6 @@ extension Components.Schemas.EventQuestionCorrectAnswer {
     self.init(
       id: answer.id.uuidString,
       eventQuestionID: answer.eventQuestionID.uuidString,
-      wineStyleID: answer.wineStyleID?.uuidString,
       wineRegionID: answer.wineRegionID?.uuidString,
       vintage: answer.vintage.map(Int32.init),
       alcoholByVolume: answer.alcoholByVolume,
@@ -1401,7 +1388,6 @@ extension Components.Schemas.EventQuestionResponse {
       id: response.id.uuidString,
       eventQuestionID: response.eventQuestionID.uuidString,
       userID: response.userID.uuidString,
-      wineStyleID: response.wineStyleID?.uuidString,
       wineRegionID: response.wineRegionID?.uuidString,
       vintage: response.vintage.map(Int32.init),
       alcoholByVolume: response.alcoholByVolume,

--- a/Sources/App/Model/EventRecords.swift
+++ b/Sources/App/Model/EventRecords.swift
@@ -121,7 +121,6 @@ struct WineRegionRecord: Codable, Identifiable, Hashable {
 struct EventQuestionCorrectAnswerRecord: Codable, Identifiable, Hashable {
   var id: UUID
   @Column("event_question_id") var eventQuestionID: UUID
-  @Column("wine_style_id") var wineStyleID: UUID?
   @Column("wine_region_id") var wineRegionID: UUID?
   var vintage: Int?
   @Column("alcohol_by_volume") var alcoholByVolume: Double?
@@ -140,7 +139,6 @@ struct EventQuestionResponseRecord: Codable, Identifiable, Hashable {
   var id: UUID
   @Column("event_question_id") var eventQuestionID: UUID
   @Column("user_id") var userID: UUID
-  @Column("wine_style_id") var wineStyleID: UUID?
   @Column("wine_region_id") var wineRegionID: UUID?
   var vintage: Int?
   @Column("alcohol_by_volume") var alcoholByVolume: Double?

--- a/public/documents/openapi.yml
+++ b/public/documents/openapi.yml
@@ -1263,9 +1263,6 @@ components:
       type: object
       description: A request to create the correct answer for a question.
       properties:
-        wineStyleID:
-          type: string
-          format: uuid
         wineRegionID:
           type: string
           format: uuid
@@ -1294,9 +1291,6 @@ components:
           type: string
           format: uuid
         eventQuestionID:
-          type: string
-          format: uuid
-        wineStyleID:
           type: string
           format: uuid
         wineRegionID:
@@ -1329,9 +1323,6 @@ components:
       type: object
       description: A request to submit a response for a question.
       properties:
-        wineStyleID:
-          type: string
-          format: uuid
         wineRegionID:
           type: string
           format: uuid
@@ -1365,9 +1356,6 @@ components:
           type: string
           format: uuid
         userID:
-          type: string
-          format: uuid
-        wineStyleID:
           type: string
           format: uuid
         wineRegionID:


### PR DESCRIPTION
## Summary
- Remove `wineStyleID` from event correct answer and response request/response schemas.
- Drop answer/response revision `wine_style_id` columns, constraints, and indexes with a forward migration.
- Keep `WineVariety.wineStyleIDs` / `wine_variety_styles` as variety-filtering master data.

## Tests
- `atlas migrate hash --dir file://Database/migrations`
- `atlas migrate validate --dir file://Database/migrations`
- `swift build`
- `git diff --check`

Closes #244