### PR TITLE
Move email verification OTP to request body

### DIFF
--- a/Sources/App/API/ConfirmEmail.swift
+++ b/Sources/App/API/ConfirmEmail.swift
@@ -20,7 +20,11 @@ extension API {
       throw HTTPError(.tooManyRequests)
     }
 
-    let email = normalizeEmail(input.query.email)
+    guard case .json(let bodyData) = input.body else {
+      return .badRequest
+    }
+
+    let email = normalizeEmail(bodyData.email)
     // 1. Verify otp
     do {
       let otpData = try await cache.get(ValkeyKey("OTPEmailRegistration:\(userID.uuidString)"))
@@ -33,7 +37,7 @@ extension API {
       guard otp.userID == userID && otp.email == email else {
         return .badRequest
       }
-      let message = Data(input.query.password.utf8)
+      let message = Data(bodyData.otp.utf8)
       guard
         HMAC<SHA256>.isValidAuthenticationCode(
           otp.hashedPassword,

--- a/public/app.js
+++ b/public/app.js
@@ -1729,11 +1729,12 @@
       },
 
       async confirmEmailAddress({ email, code, token }) {
-        const url = new URL('/email/verify', window.location.origin);
-        url.searchParams.set('email', email);
-        url.searchParams.set('password', code);
-        await post(url, {
-          headers: { Authorization: `Bearer ${token}` },
+        await post('/email/verify', {
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({ email, otp: code }),
           message: 'メールアドレスの確認に失敗しました。',
         });
       },

--- a/public/documents/openapi.yml
+++ b/public/documents/openapi.yml
@@ -809,20 +809,12 @@ paths:
       operationId: confirmEmail
       security:
         - bearerAuth: []
-      parameters:
-        - name: email
-          in: query
-          description: Email address being verified for the authenticated user.
-          required: true
-          schema:
-            type: string
-            format: email
-        - name: password
-          in: query
-          description: One-time password sent to the email address.
-          required: true
-          schema:
-            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ConfirmEmailRequest'
       responses:
         '200':
           description: A success response indicating the email address was verified.
@@ -1610,5 +1602,19 @@ components:
           description: Raw credential identifier in Base64URL format.
       required:
         - challenge
+        - email
+        - otp
+    ConfirmEmailRequest:
+      type: object
+      description: Email verification payload.
+      properties:
+        email:
+          type: string
+          format: email
+          description: Email address being verified for the authenticated user.
+        otp:
+          type: string
+          description: One-time password sent to the email address.
+      required:
         - email
         - otp


### PR DESCRIPTION
closes #190

## Summary

- Move `POST /email/verify` from `email`/`password` query parameters to a JSON request body.
- Rename the OTP field exposed by the API from `password` to `otp`.
- Update the browser demo client to send the confirmation code in the request body.

## Why

Email confirmation OTPs should not be placed in URLs because they can be retained in browser history, proxy logs, referrers, and access logs. The existing tracing redaction helps inside the app, but it cannot prevent URL exposure outside the app.

## Validation

- `swift build`
