### PR TITLE
Validate normalized email OTP inputs

### DIFF
--- a/Sources/App/API/ConfirmEmail.swift
+++ b/Sources/App/API/ConfirmEmail.swift
@@ -24,7 +24,9 @@ extension API {
       return .badRequest
     }
 
-    let email = normalizeEmail(bodyData.email)
+    guard let email = validatedEmail(bodyData.email) else {
+      return .badRequest
+    }
     // 1. Verify otp
     do {
       let otpData = try await cache.get(ValkeyKey("OTPEmailRegistration:\(userID.uuidString)"))

--- a/Sources/App/API/EmailValidation.swift
+++ b/Sources/App/API/EmailValidation.swift
@@ -8,7 +8,8 @@ func normalizeEmail(_ email: String) -> String {
 func validatedEmail(_ email: String) -> String? {
   let normalizedEmail = normalizeEmail(email)
   // https://html.spec.whatwg.org/multipage/input.html#email-state-(type=email)
-  let emailRegex = #"^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$"#
+  let emailRegex =
+    #"^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$"#
   guard
     normalizedEmail.range(
       of: emailRegex,

--- a/Sources/App/API/EmailValidation.swift
+++ b/Sources/App/API/EmailValidation.swift
@@ -1,0 +1,19 @@
+import Algorithms
+import Foundation
+
+func normalizeEmail(_ email: String) -> String {
+  email.trimming(while: \.isWhitespace).lowercased()
+}
+
+func validatedEmail(_ email: String) -> String? {
+  let normalizedEmail = normalizeEmail(email)
+  guard normalizedEmail.count <= 254,
+    normalizedEmail.range(
+      of: #"^[A-Z0-9.!#$%&'*+/=?^_`{|}~-]{1,64}@[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?(?:\.[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?)+$"#,
+      options: [.regularExpression, .caseInsensitive]
+    ) != nil
+  else {
+    return nil
+  }
+  return normalizedEmail
+}

--- a/Sources/App/API/EmailValidation.swift
+++ b/Sources/App/API/EmailValidation.swift
@@ -7,10 +7,12 @@ func normalizeEmail(_ email: String) -> String {
 
 func validatedEmail(_ email: String) -> String? {
   let normalizedEmail = normalizeEmail(email)
-  guard normalizedEmail.count <= 254,
+  // https://html.spec.whatwg.org/multipage/input.html#email-state-(type=email)
+  let emailRegex = #"^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$"#
+  guard
     normalizedEmail.range(
-      of: #"^[A-Z0-9.!#$%&'*+/=?^_`{|}~-]{1,64}@[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?(?:\.[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?)+$"#,
-      options: [.regularExpression, .caseInsensitive]
+      of: emailRegex,
+      options: .regularExpression
     ) != nil
   else {
     return nil

--- a/Sources/App/API/GetTokenFromEmail.swift
+++ b/Sources/App/API/GetTokenFromEmail.swift
@@ -25,7 +25,9 @@ extension API {
     }
 
     // 2. Verify and delete challenge atomically
-    let email: String = normalizeEmail(bodyData.email)
+    guard let email = validatedEmail(bodyData.email) else {
+      return .badRequest
+    }
     do {
       let challengeData = try Data(bodyData.challenge.base64decoded())
       let key = ValkeyKey("OTPEmailAuthentication:\(challengeData.base64EncodedString())")

--- a/Sources/App/API/SendConfirmEmail.swift
+++ b/Sources/App/API/SendConfirmEmail.swift
@@ -20,7 +20,9 @@ extension API {
       throw HTTPError(.tooManyRequests)
     }
 
-    let normalizedEmail = normalizeEmail(input.query.email)
+    guard let normalizedEmail = validatedEmail(input.query.email) else {
+      return .badRequest
+    }
     let otpPassword = OTPGenerator().generate(length: 6)
 
     let message = EmailMessage(
@@ -75,9 +77,5 @@ extension API {
     }
 
     return .ok
-  }
-
-  func normalizeEmail(_ email: String) -> String {
-    email.trimming(while: \.isWhitespace).lowercased()
   }
 }

--- a/Sources/App/API/SendEmailForToken.swift
+++ b/Sources/App/API/SendEmailForToken.swift
@@ -20,7 +20,9 @@ extension API {
     else {
       throw HTTPError(.tooManyRequests)
     }
-    let email: String = normalizeEmail(input.query.email)
+    guard let email = validatedEmail(input.query.email) else {
+      return .badRequest
+    }
     let challenge = [UInt8].random(count: 32)
 
     // 2. Generate OTP

--- a/Tests/AppTests/EmailValidationTests.swift
+++ b/Tests/AppTests/EmailValidationTests.swift
@@ -7,11 +7,12 @@ struct EmailValidationTests {
   func validatedEmailNormalizesValidEmail() {
     #expect(validatedEmail(" User+tag@Example.COM ") == "user+tag@example.com")
     #expect(validatedEmail("zunda.dev@gmail.com") == "zunda.dev@gmail.com")
+    #expect(validatedEmail("user@example") == "user@example")
   }
 
   @Test
   func validatedEmailRejectsEmptyAndInvalidEmail() {
-    for email in ["", "   ", "not-an-email", "user@", "@example.com", "user@example"] {
+    for email in ["", "   ", "not-an-email", "user@", "@example.com"] {
       #expect(validatedEmail(email) == nil)
     }
   }

--- a/Tests/AppTests/EmailValidationTests.swift
+++ b/Tests/AppTests/EmailValidationTests.swift
@@ -1,0 +1,18 @@
+import Testing
+
+@testable import App
+
+struct EmailValidationTests {
+  @Test
+  func validatedEmailNormalizesValidEmail() {
+    #expect(validatedEmail(" User+tag@Example.COM ") == "user+tag@example.com")
+    #expect(validatedEmail("zunda.dev@gmail.com") == "zunda.dev@gmail.com")
+  }
+
+  @Test
+  func validatedEmailRejectsEmptyAndInvalidEmail() {
+    for email in ["", "   ", "not-an-email", "user@", "@example.com", "user@example"] {
+      #expect(validatedEmail(email) == nil)
+    }
+  }
+}

--- a/public/documents/openapi.yml
+++ b/public/documents/openapi.yml
@@ -1637,10 +1637,11 @@ components:
           description: Base64URL-encoded challenge issued by the server.
         email:
           type: string
-          description: Credential identifier encoded in Base64URL.
+          format: email
+          description: Email address used for OTP authentication.
         otp:
           type: string
-          description: Raw credential identifier in Base64URL format.
+          description: One-time password sent to the email address.
       required:
         - challenge
         - email


### PR DESCRIPTION
## Summary
- add shared normalized email validation for email OTP flows
- reject invalid email input before cache writes or email sends
- update OpenAPI email token schema descriptions
- add focused email validation tests

## Validation
- swift test --filter EmailValidationTests

Closes #191