### PR TITLE
Validate OTP secret key Base64

### DIFF
--- a/Sources/App/BuildApplication.swift
+++ b/Sources/App/BuildApplication.swift
@@ -23,6 +23,12 @@ import WebAuthn
 // for graceful shutdown. Production only ever calls buildApplication once.
 private let observabilityBootstrapped: Mutex<Bool> = .init(false)
 
+struct OTPSecretKeyConfigurationError: Error, CustomStringConvertible {
+  var description: String {
+    "OTP secret key must be valid Base64"
+  }
+}
+
 private struct AlreadyBootstrappedObservabilityService: Service {
   func run() async throws {
     try await gracefulShutdown()
@@ -255,7 +261,7 @@ func makeAppleAppSiteAssociation(config: ConfigReader) throws -> AppleAppSiteAss
 func makeOTPSecretKey(config: ConfigReader) throws -> SymmetricKey {
   let secretKey = try config.requiredString(forKey: "otp.secret.key")
   guard let secretKeyData = Data(base64Encoded: secretKey) else {
-    throw HTTPError(.internalServerError, message: "OTP secret key must be valid Base64")
+    throw OTPSecretKeyConfigurationError()
   }
   return SymmetricKey(data: secretKeyData)
 }

--- a/Sources/App/BuildApplication.swift
+++ b/Sources/App/BuildApplication.swift
@@ -254,7 +254,9 @@ func makeAppleAppSiteAssociation(config: ConfigReader) throws -> AppleAppSiteAss
 
 func makeOTPSecretKey(config: ConfigReader) throws -> SymmetricKey {
   let secretKey = try config.requiredString(forKey: "otp.secret.key")
-  let secretKeyData = Data(base64Encoded: secretKey)!
+  guard let secretKeyData = Data(base64Encoded: secretKey) else {
+    throw HTTPError(.internalServerError, message: "OTP secret key must be valid Base64")
+  }
   return SymmetricKey(data: secretKeyData)
 }
 


### PR DESCRIPTION
## Summary
- Replace the forced unwrap in makeOTPSecretKey with an explicit invalid Base64 error.
- Keep the change scoped to OTP secret configuration startup handling.

## Tests
- swift build
- swift format lint -r -p -s Sources/App Tests/AppTests
- git diff --check

Closes #186