### PR TITLE
Skip login OTP for unregistered email

### DIFF
--- a/Sources/App/API/SendEmailForToken.swift
+++ b/Sources/App/API/SendEmailForToken.swift
@@ -23,6 +23,36 @@ extension API {
     guard let email = validatedEmail(input.query.email) else {
       return .badRequest
     }
+    let isRegisteredEmail: Bool
+    do {
+      isRegisteredEmail = try await database.read { db in
+        try await UserEmail
+          .where { $0.email.eq(email) }
+          .select { $0.email }
+          .fetchOne(db) != nil
+      }
+    } catch {
+      AppRequestContext.current?.logger.appError(
+        eventName: "auth.email.registration_lookup_failed",
+        "Failed to check email registration before sending OTP",
+        metadata: AppLogMetadata.emailSHA256(email).merging([
+          "db.operation": .string("select")
+        ]) { _, new in new },
+        error: error
+      )
+      return .badRequest
+    }
+
+    guard isRegisteredEmail else {
+      AppRequestContext.current?.logger.appLog(
+        level: .debug,
+        eventName: "auth.email.unregistered_login_requested",
+        "Skipping login OTP for unregistered email",
+        metadata: AppLogMetadata.emailSHA256(email)
+      )
+      return .ok(.init(body: .json(.init([]))))
+    }
+
     let challenge = [UInt8].random(count: 32)
 
     // 2. Generate OTP

--- a/Tests/AppTests/RouterTests.swift
+++ b/Tests/AppTests/RouterTests.swift
@@ -1232,6 +1232,32 @@ struct RouterTests {
   }
 
   @Test
+  func sendEmailForTokenSkipsUnregisteredEmail() async throws {
+    let arguments = TestArguments()
+    let emailRecorder = TestEmailServiceCallRecorder()
+    let app = try await buildApplication(
+      arguments,
+      cloudflareImagesClient: TestCloudflareImagesClient(),
+      emailService: TestEmailService(recorder: emailRecorder)
+    )
+    let ipAddress = UUID().uuidString
+    let email = "\(UUID().uuidString)@example.com"
+
+    try await app.test(.router) { client in
+      let response = try await client.execute(
+        uri: "/token/email/start?email=\(email)",
+        method: .post,
+        headers: [
+          .cfConnectingIP: ipAddress
+        ]
+      )
+
+      #expect(response.status == .ok)
+      #expect(await emailRecorder.sendCount == 0)
+    }
+  }
+
+  @Test
   func ipAddressRateLimit() async throws {
     let arguments = TestArguments()
     let app = try await buildApplication(arguments)
@@ -1408,8 +1434,11 @@ private struct TestCloudflareImagesClient: CloudflareImagesClientProtocol {
 }
 
 private struct TestEmailService: EmailServiceProtocol {
+  var recorder: TestEmailServiceCallRecorder? = nil
+
   func send(_ email: EmailMessage) async throws -> EmailResponse.Result {
-    EmailResponse.Result(delivered: [], permanentBounces: [], queued: [])
+    await recorder?.recordSend()
+    return EmailResponse.Result(delivered: [], permanentBounces: [], queued: [])
   }
 }
 
@@ -1579,6 +1608,14 @@ private struct TestWebAuthn: WebAuthnProtocol {
 }
 
 private struct TestWebAuthnError: Error {}
+
+private actor TestEmailServiceCallRecorder {
+  private(set) var sendCount = 0
+
+  func recordSend() {
+    sendCount += 1
+  }
+}
 
 private actor TestCloudflareImagesCallRecorder {
   private(set) var createDirectUploadURLCount = 0


### PR DESCRIPTION
## Summary
- Check `user_email` before generating, caching, or sending login OTPs in `sendEmailForToken`.
- Return `200` with an empty payload for unregistered email addresses to avoid user enumeration.
- Log `auth.email.unregistered_login_requested` (debug) when skipping, and `auth.email.registration_lookup_failed` when the lookup fails (returns `400`).
- Add a router test (`sendEmailForTokenSkipsUnregisteredEmail`) with a fake `EmailService` verifying unregistered email does not send mail.

Closes #217
