### PR TITLE
Return unauthorized for invalid refresh JWT

### DIFF
--- a/Sources/App/API/RefreshToken.swift
+++ b/Sources/App/API/RefreshToken.swift
@@ -13,7 +13,18 @@ extension API {
       return .badRequest
     }
 
-    let payload = try await jwtKeyCollection.verify(body.refreshToken, as: JWTPayloadData.self)
+    let payload: JWTPayloadData
+    do {
+      payload = try await jwtKeyCollection.verify(body.refreshToken, as: JWTPayloadData.self)
+    } catch {
+      AppRequestContext.current?.logger.appLog(
+        level: .debug,
+        eventName: "auth.refresh_token.verify_failed",
+        "Couldn't verify refresh token",
+        error: error
+      )
+      return .unauthorized
+    }
 
     guard let userID = UUID(uuidString: payload.subject.value) else {
       AppRequestContext.current?.logger.appLog(

--- a/Tests/AppTests/RouterTests.swift
+++ b/Tests/AppTests/RouterTests.swift
@@ -901,6 +901,29 @@ struct RouterTests {
   }
 
   @Test
+  func refreshTokenRejectsInvalidJWT() async throws {
+    let arguments = TestArguments()
+    let app = try await buildApplication(
+      arguments,
+      cloudflareImagesClient: TestCloudflareImagesClient()
+    )
+    let ipAddress = UUID().uuidString
+
+    try await app.test(.router) { client in
+      let response = try await client.execute(
+        uri: "/refreshToken",
+        method: .post,
+        headers: [
+          .cfConnectingIP: ipAddress
+        ],
+        body: ByteBuffer(data: JSONEncoder().encode(["refreshToken": "invalid-token"]))
+      )
+
+      #expect(response.status == .unauthorized)
+    }
+  }
+
+  @Test
   func revokeToken() async throws {
     let arguments = TestArguments()
     let app = try await buildApplication(arguments)


### PR DESCRIPTION
## Summary
- Catch refreshToken JWT verification failures and normalize them to 401 Unauthorized.
- Add a router test for malformed refresh tokens.

## Tests
- swift build
- swift format lint -r -p -s Sources/App Tests/AppTests
- git diff --check
- swift test --filter RouterTests/refreshTokenRejectsInvalidJWT

Closes #213