### PR TITLE
Stabilize response id and stop leaking profile revision id

### DIFF
--- a/Database/migrations/20260614020000_response_aggregate.sql
+++ b/Database/migrations/20260614020000_response_aggregate.sql
@@ -1,0 +1,53 @@
+-- Introduce a stable aggregate for a user's response to a question, mirroring
+-- the events <-> event_revisions relationship (and the correct-answer fix). The
+-- append-only revisions table now references the aggregate instead of carrying
+-- (event_question_id, user_id) directly, so the API can return an `id` that
+-- stays unchanged across updates.
+
+-- 1. Aggregate table: one stable response row per (question, user).
+CREATE TABLE public.event_question_responses (
+  id uuid NOT NULL,
+  event_question_id uuid NOT NULL,
+  user_id uuid NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT event_question_responses_pk PRIMARY KEY (id),
+  CONSTRAINT event_question_responses_event_question_fk FOREIGN KEY (event_question_id) REFERENCES public.event_questions (id) ON DELETE RESTRICT,
+  CONSTRAINT event_question_responses_user_fk FOREIGN KEY (user_id) REFERENCES public.users (id) ON DELETE RESTRICT,
+  CONSTRAINT event_question_responses_event_question_user_key UNIQUE (event_question_id, user_id)
+);
+
+CREATE INDEX event_question_responses_user_id_idx ON public.event_question_responses(user_id);
+
+-- 2. Backfill one aggregate per (question, user). Use a fresh id and carry over
+--    the oldest revision's submitted_at as the initial submission time.
+INSERT INTO public.event_question_responses (id, event_question_id, user_id, created_at)
+SELECT DISTINCT ON (r.event_question_id, r.user_id)
+  gen_random_uuid(), r.event_question_id, r.user_id, r.submitted_at
+FROM public.event_question_response_revisions r
+ORDER BY r.event_question_id, r.user_id, r.submitted_at ASC, r.id ASC;
+
+-- 3. Link existing revisions to their aggregate.
+ALTER TABLE public.event_question_response_revisions
+  ADD COLUMN event_question_response_id uuid;
+
+UPDATE public.event_question_response_revisions r
+SET event_question_response_id = a.id
+FROM public.event_question_responses a
+WHERE a.event_question_id = r.event_question_id
+  AND a.user_id = r.user_id;
+
+ALTER TABLE public.event_question_response_revisions
+  ALTER COLUMN event_question_response_id SET NOT NULL,
+  ADD CONSTRAINT event_question_response_revisions_response_fk FOREIGN KEY (event_question_response_id) REFERENCES public.event_question_responses (id) ON DELETE RESTRICT;
+
+-- 4. Drop the now-redundant direct links to event_questions / users.
+DROP INDEX IF EXISTS public.event_question_response_revisions_event_question_user_latest_idx;
+DROP INDEX IF EXISTS public.event_question_response_revisions_user_id_idx;
+
+ALTER TABLE public.event_question_response_revisions
+  DROP CONSTRAINT IF EXISTS event_question_response_revisions_event_question_fk,
+  DROP CONSTRAINT IF EXISTS event_question_response_revisions_user_fk,
+  DROP COLUMN IF EXISTS event_question_id,
+  DROP COLUMN IF EXISTS user_id;
+
+CREATE INDEX event_question_response_revisions_response_latest_idx ON public.event_question_response_revisions(event_question_response_id, submitted_at DESC, id DESC);

--- a/Database/migrations/atlas.sum
+++ b/Database/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:TLDfVEnXz8BSQuyKI7Xh9y7xyzgf8KIR6YNesIKYn3U=
+h1:IoivRpcxvFHmFXwgfytPEcAhmnBnx639d1yI2xsKOyI=
 000001_initial_schema.sql h1:iQH63d3ckYBCOcFnKf6nkOsitlGdpumeDPFZMcnCuz4=
 20260531034124_events.sql h1:PedeyzF85utC/LHxKCc9z5Gs8puDptsTNkRapWNKjrI=
 20260531060000_seed_wine_master_data.sql h1:54BEUlfrgkN/2W4aM32RYFg5x74O9IeSS/lR0v04t7g=
@@ -6,3 +6,4 @@ h1:TLDfVEnXz8BSQuyKI7Xh9y7xyzgf8KIR6YNesIKYn3U=
 20260603120000_remove_answer_wine_style_id.sql h1:rD0HPVkxOK6bueWprhfrpD0no9c3hvP/+OvEKOEGNic=
 20260614000000_event_numeric_to_double.sql h1:HYqgZIhm49OAktZVbjez1REs+kI/kqPcAoZX6BViHeE=
 20260614010000_correct_answer_aggregate.sql h1:ocjHzVrl5ods0XrvXy9gNvLXPoR7O3nCoN/wzn/4mRA=
+20260614020000_response_aggregate.sql h1:7VhFaEnN4OqUqhR/6YICgw42hTToFVPc1Yc1Y/Rq3ug=

--- a/Database/schema.sql
+++ b/Database/schema.sql
@@ -271,25 +271,35 @@ CREATE TABLE public.event_question_correct_answer_revision_varieties (
 
 CREATE INDEX event_question_correct_answer_revision_varieties_wine_variety_id_idx ON public.event_question_correct_answer_revision_varieties(wine_variety_id);
 
-CREATE TABLE public.event_question_response_revisions (
+CREATE TABLE public.event_question_responses (
   id uuid NOT NULL,
   event_question_id uuid NOT NULL,
   user_id uuid NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT event_question_responses_pk PRIMARY KEY (id),
+  CONSTRAINT event_question_responses_event_question_fk FOREIGN KEY (event_question_id) REFERENCES public.event_questions (id) ON DELETE RESTRICT,
+  CONSTRAINT event_question_responses_user_fk FOREIGN KEY (user_id) REFERENCES public.users (id) ON DELETE RESTRICT,
+  CONSTRAINT event_question_responses_event_question_user_key UNIQUE (event_question_id, user_id)
+);
+
+CREATE INDEX event_question_responses_user_id_idx ON public.event_question_responses(user_id);
+
+CREATE TABLE public.event_question_response_revisions (
+  id uuid NOT NULL,
+  event_question_response_id uuid NOT NULL,
   wine_region_id uuid,
   vintage integer,
   alcohol_by_volume double precision,
   note text,
   submitted_at timestamptz NOT NULL,
   CONSTRAINT event_question_response_revisions_pk PRIMARY KEY (id),
-  CONSTRAINT event_question_response_revisions_event_question_fk FOREIGN KEY (event_question_id) REFERENCES public.event_questions (id) ON DELETE RESTRICT,
-  CONSTRAINT event_question_response_revisions_user_fk FOREIGN KEY (user_id) REFERENCES public.users (id) ON DELETE RESTRICT,
+  CONSTRAINT event_question_response_revisions_response_fk FOREIGN KEY (event_question_response_id) REFERENCES public.event_question_responses (id) ON DELETE RESTRICT,
   CONSTRAINT event_question_response_revisions_wine_region_fk FOREIGN KEY (wine_region_id) REFERENCES public.wine_regions (id) ON DELETE RESTRICT,
   CONSTRAINT event_question_response_revisions_vintage_positive CHECK (vintage IS NULL OR vintage > 0),
   CONSTRAINT event_question_response_revisions_alcohol_by_volume_range CHECK (alcohol_by_volume IS NULL OR (alcohol_by_volume >= 0 AND alcohol_by_volume <= 100))
 );
 
-CREATE INDEX event_question_response_revisions_event_question_user_latest_idx ON public.event_question_response_revisions(event_question_id, user_id, submitted_at DESC, id DESC);
-CREATE INDEX event_question_response_revisions_user_id_idx ON public.event_question_response_revisions(user_id);
+CREATE INDEX event_question_response_revisions_response_latest_idx ON public.event_question_response_revisions(event_question_response_id, submitted_at DESC, id DESC);
 CREATE INDEX event_question_response_revisions_wine_region_id_idx ON public.event_question_response_revisions(wine_region_id);
 
 CREATE TABLE public.event_question_response_revision_varieties (

--- a/Sources/App/API/Events.swift
+++ b/Sources/App/API/Events.swift
@@ -558,7 +558,7 @@ extension API {
       else {
         return .notFound
       }
-      let response = try await insertQuestionResponse(
+      let result = try await insertQuestionResponse(
         questionID: questionID,
         userID: userID,
         regionID: regionID,
@@ -568,7 +568,14 @@ extension API {
         varietyIDs: varietyIDs,
         requireNoExistingResponse: true
       )
-      return .ok(.init(body: .json(.init(response, wineVarietyIDs: varietyIDs))))
+      return .ok(
+        .init(
+          body: .json(
+            .init(
+              response: result.response,
+              revision: result.revision,
+              wineVarietyIDs: varietyIDs
+            ))))
     } catch EventRevisionMutationError.alreadyExists {
       return .badRequest
     } catch {
@@ -611,7 +618,7 @@ extension API {
         return .notFound
       }
 
-      let response = try await insertQuestionResponse(
+      let result = try await insertQuestionResponse(
         questionID: questionID,
         userID: userID,
         regionID: regionID,
@@ -621,7 +628,14 @@ extension API {
         varietyIDs: varietyIDs,
         requireExistingResponse: true
       )
-      return .ok(.init(body: .json(.init(response, wineVarietyIDs: varietyIDs))))
+      return .ok(
+        .init(
+          body: .json(
+            .init(
+              response: result.response,
+              revision: result.revision,
+              wineVarietyIDs: varietyIDs
+            ))))
     } catch EventRevisionMutationError.missingExistingRevision {
       return .notFound
     } catch {
@@ -1222,20 +1236,18 @@ extension API {
       .fetchOne(db)
   }
 
-  fileprivate func eventQuestionResponseExists(
+  fileprivate func eventQuestionResponse(
     questionID: UUID,
     userID: UUID,
     db: any Database.Connection.`Protocol`
-  ) async throws -> Bool {
-    let response =
-      try await EventQuestionResponseRecord
+  ) async throws -> EventQuestionResponseRecord? {
+    try await EventQuestionResponseRecord
       .where {
         $0.eventQuestionID.eq(questionID)
           .and($0.userID.eq(userID))
       }
       .limit(1)
       .fetchOne(db)
-    return response != nil
   }
 
   fileprivate func insertCorrectAnswer(
@@ -1304,47 +1316,52 @@ extension API {
     varietyIDs: [UUID],
     requireNoExistingResponse: Bool = false,
     requireExistingResponse: Bool = false
-  ) async throws -> EventQuestionResponseRecord {
-    let response = EventQuestionResponseRecord(
-      id: UUID(uuidString: UUID.uuidV7String())!,
-      eventQuestionID: questionID,
-      userID: userID,
-      wineRegionID: regionID,
-      vintage: vintage,
-      alcoholByVolume: alcoholByVolume,
-      note: note,
-      submittedAt: Date()
-    )
+  ) async throws -> (
+    response: EventQuestionResponseRecord, revision: EventQuestionResponseRevisionRecord
+  ) {
     try await database.withTransaction { db in
       if requireNoExistingResponse || requireExistingResponse {
         try await lockEventQuestion(questionID: questionID, db: db)
       }
-      if requireNoExistingResponse {
-        guard
-          try await eventQuestionResponseExists(
-            questionID: questionID,
-            userID: userID,
-            db: db
-          ) == false
-        else {
-          throw EventRevisionMutationError.alreadyExists
-        }
+      // The aggregate carries the stable id and first-submission time; each
+      // update only appends a new revision, mirroring the events ↔
+      // event_revisions pattern.
+      let existing = try await eventQuestionResponse(
+        questionID: questionID,
+        userID: userID,
+        db: db
+      )
+      if requireNoExistingResponse, existing != nil {
+        throw EventRevisionMutationError.alreadyExists
       }
-      if requireExistingResponse {
-        guard
-          try await eventQuestionResponseExists(
-            questionID: questionID,
-            userID: userID,
-            db: db
-          )
-        else {
-          throw EventRevisionMutationError.missingExistingRevision
-        }
+      if requireExistingResponse, existing == nil {
+        throw EventRevisionMutationError.missingExistingRevision
       }
-      try await EventQuestionResponseRecord.insert { response }.execute(db)
+      let response: EventQuestionResponseRecord
+      if let existing {
+        response = existing
+      } else {
+        response = EventQuestionResponseRecord(
+          id: UUID(uuidString: UUID.uuidV7String())!,
+          eventQuestionID: questionID,
+          userID: userID,
+          createdAt: Date()
+        )
+        try await EventQuestionResponseRecord.insert { response }.execute(db)
+      }
+      let revision = EventQuestionResponseRevisionRecord(
+        id: UUID(uuidString: UUID.uuidV7String())!,
+        eventQuestionResponseID: response.id,
+        wineRegionID: regionID,
+        vintage: vintage,
+        alcoholByVolume: alcoholByVolume,
+        note: note,
+        submittedAt: Date()
+      )
+      try await EventQuestionResponseRevisionRecord.insert { revision }.execute(db)
       let responseVarieties = varietyIDs.map { varietyID in
         EventQuestionResponseVarietyRecord(
-          eventQuestionResponseID: response.id,
+          eventQuestionResponseRevisionID: revision.id,
           wineVarietyID: varietyID,
           createdAt: Date()
         )
@@ -1352,8 +1369,8 @@ extension API {
       if !responseVarieties.isEmpty {
         try await EventQuestionResponseVarietyRecord.insert { responseVarieties }.execute(db)
       }
+      return (response, revision)
     }
-    return response
   }
 
   fileprivate func parseOptionalUUID(_ string: String?) -> (id: UUID?, isValid: Bool) {
@@ -1524,17 +1541,21 @@ extension Components.Schemas.EventQuestionCorrectAnswer {
 }
 
 extension Components.Schemas.EventQuestionResponse {
-  init(_ response: EventQuestionResponseRecord, wineVarietyIDs: [UUID]) {
+  init(
+    response: EventQuestionResponseRecord,
+    revision: EventQuestionResponseRevisionRecord,
+    wineVarietyIDs: [UUID]
+  ) {
     self.init(
       id: response.id.uuidString,
       eventQuestionID: response.eventQuestionID.uuidString,
       userID: response.userID.uuidString,
-      wineRegionID: response.wineRegionID?.uuidString,
-      vintage: response.vintage.map(Int32.init),
-      alcoholByVolume: response.alcoholByVolume,
-      note: response.note,
+      wineRegionID: revision.wineRegionID?.uuidString,
+      vintage: revision.vintage.map(Int32.init),
+      alcoholByVolume: revision.alcoholByVolume,
+      note: revision.note,
       wineVarietyIDs: wineVarietyIDs.map(\.uuidString),
-      submittedAt: response.submittedAt.timeIntervalSinceReferenceDate
+      submittedAt: response.createdAt.timeIntervalSinceReferenceDate
     )
   }
 }

--- a/Sources/App/API/UserProfile.swift
+++ b/Sources/App/API/UserProfile.swift
@@ -366,7 +366,6 @@ extension API {
 extension Components.Schemas.UserProfile {
   fileprivate init(_ profile: UserProfile, imageURL: String?) {
     self.init(
-      id: profile.id.uuidString,
       userID: profile.userID!.uuidString,
       name: profile.name!,
       imageURL: imageURL,

--- a/Sources/App/Model/EventRecords.swift
+++ b/Sources/App/Model/EventRecords.swift
@@ -150,11 +150,18 @@ struct EventQuestionCorrectAnswerVarietyRecord: Codable, Hashable {
   @Column("created_at") var createdAt: Date
 }
 
-@Table("event_question_response_revisions")
+@Table("event_question_responses")
 struct EventQuestionResponseRecord: Codable, Identifiable, Hashable {
   var id: UUID
   @Column("event_question_id") var eventQuestionID: UUID
   @Column("user_id") var userID: UUID
+  @Column("created_at") var createdAt: Date
+}
+
+@Table("event_question_response_revisions")
+struct EventQuestionResponseRevisionRecord: Codable, Identifiable, Hashable {
+  var id: UUID
+  @Column("event_question_response_id") var eventQuestionResponseID: UUID
   @Column("wine_region_id") var wineRegionID: UUID?
   var vintage: Int?
   @Column("alcohol_by_volume") var alcoholByVolume: Double?
@@ -164,7 +171,7 @@ struct EventQuestionResponseRecord: Codable, Identifiable, Hashable {
 
 @Table("event_question_response_revision_varieties")
 struct EventQuestionResponseVarietyRecord: Codable, Hashable {
-  @Column("event_question_response_revision_id") var eventQuestionResponseID: UUID
+  @Column("event_question_response_revision_id") var eventQuestionResponseRevisionID: UUID
   @Column("wine_variety_id") var wineVarietyID: UUID
   @Column("created_at") var createdAt: Date
 }

--- a/Tests/AppTests/RouterTests.swift
+++ b/Tests/AppTests/RouterTests.swift
@@ -218,7 +218,7 @@ struct RouterTests {
         #expect(response.status == .ok)
         return try JSONDecoder().decode(Components.Schemas.UserProfile.self, from: response.body)
       }
-      #expect(firstProfile.id != secondProfile.id)
+      #expect(secondProfile.userID == newUser.userID)
       #expect(secondProfile.name == "Bob")
       #expect(secondProfile.imageURL == nil)
 
@@ -235,7 +235,7 @@ struct RouterTests {
           Components.Schemas.UserProfile.self,
           from: response.body
         )
-        #expect(profile.id == secondProfile.id)
+        #expect(profile.userID == secondProfile.userID)
         #expect(profile.name == "Bob")
         #expect(profile.imageURL == nil)
       }
@@ -314,7 +314,7 @@ struct RouterTests {
           Components.Schemas.UserProfile.self,
           from: response.body
         )
-        #expect(latestProfile.id == profile.id)
+        #expect(latestProfile.userID == profile.userID)
         #expect(
           latestProfile.imageURL
             == "https://imagedelivery.net/account-hash/\(cloudflareImageID)/public")
@@ -334,7 +334,7 @@ struct RouterTests {
           Components.Schemas.UserProfile.self,
           from: response.body
         )
-        #expect(latestProfile.id == profile.id)
+        #expect(latestProfile.userID == profile.userID)
         #expect(
           latestProfile.imageURL
             == "https://imagedelivery.net/account-hash/\(cloudflareImageID)/public")

--- a/public/documents/openapi.yml
+++ b/public/documents/openapi.yml
@@ -1030,10 +1030,6 @@ components:
       type: object
       description: A value with the user profile contents.
       properties:
-        id:
-          type: string
-          format: uuid
-          description: User profile id.
         userID:
           type: string
           format: uuid
@@ -1052,7 +1048,6 @@ components:
           format: double
           description: User profile created date.
       required:
-        - id
         - userID
         - name
         - createdAt


### PR DESCRIPTION
EventQuestionResponse had the same bug just fixed for correct answers: the response was stored append-only in event_question_response_revisions and PUT returned the freshly inserted revision's id, so the response id changed on every update.

Introduce an event_question_responses aggregate (one stable row per question+user) and repoint the revisions table to it via event_question_response_id, mirroring events <-> event_revisions. The response id is now the aggregate id (stable across updates) and submittedAt is the aggregate's first-submission time. The migration backfills one aggregate per (question, user) from the oldest existing revision.

Also drop the revision-level id from the UserProfile API: a profile is a revision of the user, so its identity is userID; the user_profiles row id is internal and no longer exposed.

No response-shape change for EventQuestionResponse; UserProfile drops the id field.