### PR TITLE
Rotate refresh tokens 

### DIFF
--- a/Sources/App/API/GenerateUserToken.swift
+++ b/Sources/App/API/GenerateUserToken.swift
@@ -18,7 +18,7 @@ extension API {
       expiration: .init(value: tokenExpiredDate)
     )
 
-    let refreshTokenExpiredDate = Date(timeIntervalSinceNow: 30 * 24 * 60 * 60)  // 30 days
+    let refreshTokenExpiredDate = Date(timeIntervalSinceNow: 365 * 24 * 60 * 60)  // 1 year
 
     let refreshTokenPayload = JWTPayloadData(
       tokenType: .refreshToken,

--- a/Sources/App/API/GenerateUserToken.swift
+++ b/Sources/App/API/GenerateUserToken.swift
@@ -18,7 +18,7 @@ extension API {
       expiration: .init(value: tokenExpiredDate)
     )
 
-    let refreshTokenExpiredDate = Date(timeIntervalSinceNow: 365 * 24 * 60 * 60)  // 1 year
+    let refreshTokenExpiredDate = Date(timeIntervalSinceNow: 30 * 24 * 60 * 60)  // 30 days
 
     let refreshTokenPayload = JWTPayloadData(
       tokenType: .refreshToken,

--- a/Sources/App/API/RefreshToken.swift
+++ b/Sources/App/API/RefreshToken.swift
@@ -111,6 +111,27 @@ extension API {
       )
       return .badRequest
     }
+
+    // Rotate the refresh token: revoke the presented (old) token so it cannot be
+    // reused. A subsequent refresh with the same token is rejected by the
+    // `isRefreshTokenRevoked` check above (reuse detection). Revoke only after the
+    // new token pair has been issued; if revocation fails we withhold the new
+    // tokens (return badRequest) so the client retries with the still-valid old
+    // token rather than ending up with an un-revoked old token in circulation.
+    do {
+      try await revokeRefreshToken(payload)
+    } catch {
+      AppRequestContext.current?.logger.appError(
+        eventName: "auth.refresh_token.rotate_failed",
+        "Failed to revoke old refresh token during rotation",
+        metadata: AppLogMetadata.userID(userID).merging([
+          "cache.operation": .string("set")
+        ]) { _, new in new },
+        error: error
+      )
+      return .badRequest
+    }
+
     return .ok(.init(body: .json(userToken)))
   }
 

--- a/Sources/App/API/RefreshToken.swift
+++ b/Sources/App/API/RefreshToken.swift
@@ -112,12 +112,6 @@ extension API {
       return .badRequest
     }
 
-    // Rotate the refresh token: revoke the presented (old) token so it cannot be
-    // reused. A subsequent refresh with the same token is rejected by the
-    // `isRefreshTokenRevoked` check above (reuse detection). Revoke only after the
-    // new token pair has been issued; if revocation fails we withhold the new
-    // tokens (return badRequest) so the client retries with the still-valid old
-    // token rather than ending up with an un-revoked old token in circulation.
     do {
       try await revokeRefreshToken(payload)
     } catch {


### PR DESCRIPTION
## 概要
リフレッシュトークンをローテーションし、漏洩時の悪用ウィンドウを短縮する。

## 変更点
- リフレッシュ成功時に提示された旧リフレッシュトークンを `revokeRefreshToken` で失効（ローテーション）。同トークンの再利用は既存の `isRefreshTokenRevoked` チェックで拒否される（再利用検知）。
- 失効書き込みに失敗した場合は新トークンを返さず `badRequest`（旧トークンが失効しないまま流通するのを防ぐ）。

Closes #276