### PR TITLE
Unify base64 decode path in email OTP authentication

### DIFF
--- a/Sources/App/API/GetTokenFromEmail.swift
+++ b/Sources/App/API/GetTokenFromEmail.swift
@@ -45,7 +45,10 @@ extension API {
         return .badRequest
       }
 
-      guard challenge.challenge == Data(base64Encoded: bodyData.challenge) else {
+      // Compare against the value already decoded above rather than decoding
+      // `bodyData.challenge` a second time with a different (Foundation) decoder.
+      // A single decode path avoids URL-safe vs standard base64 mismatches.
+      guard challenge.challenge == challengeData else {
         return .unauthorized
       }
 

--- a/Sources/App/API/GetTokenFromEmail.swift
+++ b/Sources/App/API/GetTokenFromEmail.swift
@@ -45,9 +45,6 @@ extension API {
         return .badRequest
       }
 
-      // Compare against the value already decoded above rather than decoding
-      // `bodyData.challenge` a second time with a different (Foundation) decoder.
-      // A single decode path avoids URL-safe vs standard base64 mismatches.
       guard challenge.challenge == challengeData else {
         return .unauthorized
       }


### PR DESCRIPTION
## 概要
メール OTP 認証で base64 のデコード経路が混在していた（ExtrasBase64 でデコードしてキー化し、Foundation 標準デコーダで再照合）。デコードを 1 経路に統一する。

## 変更点
- 冗長な `Data(base64Encoded: bodyData.challenge)` での再デコードを廃止し、上で復号済みの `challengeData` と比較するように変更。
- 標準 base64 での動作は不変。URL-safe 文字混入時のデコーダ差による不一致リスクを排除。

Closes #278