### PR TITLE
Replace profile cache atomically with a single set

### DIFF
--- a/Sources/App/API/UserProfile.swift
+++ b/Sources/App/API/UserProfile.swift
@@ -306,9 +306,6 @@ extension API {
   }
 
   fileprivate func replaceCachedLatestProfile(_ profile: UserProfile, userID: UUID) async throws {
-    // A single SET overwrites the existing value atomically. The previous
-    // del-then-set left a small window where a concurrent request could miss
-    // the cache and fall through to the database.
     try await cacheLatestProfile(profile, userID: userID)
   }
 

--- a/Sources/App/API/UserProfile.swift
+++ b/Sources/App/API/UserProfile.swift
@@ -306,7 +306,9 @@ extension API {
   }
 
   fileprivate func replaceCachedLatestProfile(_ profile: UserProfile, userID: UUID) async throws {
-    try await cache.del(keys: [latestUserProfileCacheKey(userID)])
+    // A single SET overwrites the existing value atomically. The previous
+    // del-then-set left a small window where a concurrent request could miss
+    // the cache and fall through to the database.
     try await cacheLatestProfile(profile, userID: userID)
   }
 


### PR DESCRIPTION
## 概要
`replaceCachedLatestProfile` が `del` → `set` の順で更新しており、その間に別リクエストがキャッシュミスして DB を引く小さな窓があった。

## 変更点
- `del` を廃止し、上書きされる単一の `SET`（`cacheLatestProfile`）のみで置き換えるよう変更。窓を解消する。

Closes #280