### PR TITLE
Document that user profiles are public by design

### DIFF
--- a/Sources/App/API/UserProfile.swift
+++ b/Sources/App/API/UserProfile.swift
@@ -12,6 +12,10 @@ extension API {
   func getUserProfile(
     _ input: Operations.GetUserProfile.Input
   ) async throws -> Operations.GetUserProfile.Output {
+    // A user profile (display name and image) is intentionally public to any
+    // authenticated user: profiles are meant to be visible between users, e.g.
+    // among participants of the same event. Authentication is required, but no
+    // relationship/ownership check is applied by design.
     guard UserTokenContext.currentUserID != nil else {
       return .unauthorized
     }


### PR DESCRIPTION
## 概要
`getUserProfile` は認証済みの任意ユーザーに対してプロフィール（名前・画像）を返す。これはイベント参加者間でプロフィールを公開する意図的な設計であることを確認した。

## 変更点
- 公開設計であること（認証は必須だが関係性チェックは意図的に行わない）をコメントとして明記。動作変更なし。

Closes #279