### PR TITLE
Document that app-layer CORS is intentionally omitted

### DIFF
--- a/Sources/App/BuildApplication.swift
+++ b/Sources/App/BuildApplication.swift
@@ -122,6 +122,12 @@ func buildApplication(
   router.add(middleware: LogRequestsMiddleware(.info))
   router.add(middleware: FileMiddleware(searchForIndexHtml: true))
 
+  // No app-layer CORS middleware is configured by design. The API is consumed
+  // by the native app and the same-origin docs/HTML page (which is test-only),
+  // so there is no cross-origin browser client to support. The request trust
+  // boundary is enforced at the network layer (Cloudflare → GCP LB); see the
+  // note in RateLimitMiddleware. Add CORSMiddleware here if a cross-origin
+  // browser client is introduced.
   let apiRouter =
     router
     .group()


### PR DESCRIPTION
## 概要
アプリ層に CORS ミドルウェアがないのは意図的であることを確認した。API はネイティブアプリと同一オリジンのドキュメント/HTML ページ（テスト用）のみが利用し、クロスオリジンのブラウザクライアントは想定していない。信頼境界は Cloudflare → GCP LB のネットワーク層で担保される。

## 変更点
- CORS を意図的に設定していない理由を `BuildApplication` のミドルウェア設定箇所にコメントとして明記。動作変更なし。
- 将来クロスオリジンのブラウザクライアントを導入する場合は `CORSMiddleware` を追加する旨も記載。

Closes #281