### PR TITLE
Document CI test keys as disposable test-only credentials

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,11 @@ jobs:
       - run: swift format lint -r -p -s .
   test:
     runs-on: ubuntu-latest
+    # These env values are disposable, test-only credentials used solely to run
+    # the suite in CI. They have no relationship to production: real secrets
+    # (EDDSA_PRIVATE_KEY, OTP_SECRET_KEY, CLOUDFLARE_API_TOKEN, POSTGRES_PASSWORD,
+    # VALKEY_PASSWORD) are provisioned via Secret Manager in deploy.yml. Keeping
+    # the throwaway keys inline keeps CI self-contained and reproducible.
     env:
       APPLE_APP_ID: XXXXXXXX.com.apple.memo
       VALKEY_HOSTNAME: valkey


### PR DESCRIPTION
## 概要
`.github/workflows/ci.yml` に直書きされた `EDDSA_PRIVATE_KEY` / `OTP_SECRET_KEY` 等は、CI でテストを実行するためだけの使い捨て鍵であり本番とは無関係であることを確認した（本番鍵は `deploy.yml` で Secret Manager 経由）。

## 変更点
- これらがテスト専用の使い捨て鍵であることを `ci.yml` にコメントで明示。インライン保持により CI を自己完結・再現可能に保つ。

Closes #282