### PR TITLE
Document Cloud Run ingress restriction requirement

### DIFF
--- a/Terraform/cloud_run.tf
+++ b/Terraform/cloud_run.tf
@@ -6,8 +6,11 @@ resource "google_cloud_run_v2_service" "api" {
     google_secret_manager_secret_iam_member.runtime_access,
   ]
 
-  name                = var.service_name
-  location            = var.region
+  name     = var.service_name
+  location = var.region
+  # Must be true in production. When false, Cloud Run accepts direct *.run.app
+  # ingress, which bypasses the Cloudflare -> GCP LB trust boundary (rate
+  # limiting / IP allowlisting). See terraform.tfvars (prod sets this to true).
   ingress             = var.restrict_direct_cloud_run_ingress ? "INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER" : "INGRESS_TRAFFIC_ALL"
   deletion_protection = true
 


### PR DESCRIPTION
## 概要
本番デプロイで `restrict_direct_cloud_run_ingress = true` になっていることを確認した（`Terraform/terraform.tfvars` で既に `true`）。false の場合 Cloud Run へ `*.run.app` で直接 ingress でき、Cloudflare → GCP LB のレート制限/IP 制限の信頼境界を迂回され得る。

## 変更点
- 本番では `true` を維持する必要がある旨を `cloud_run.tf`（ingress 定義箇所）と `terraform.tfvars` にコメントで明記。設定値の変更はなし。

Closes #283