### PR TITLE
OTel app logs に検索用 metadata を追加する

### DIFF
--- a/Sources/App/AppLogMetadata.swift
+++ b/Sources/App/AppLogMetadata.swift
@@ -12,7 +12,6 @@ enum AppLogMetadata {
   ) -> Logger.Metadata {
     var metadata = sanitized(metadata)
     metadata["event.name"] = .string(eventName)
-    metadata["eventName"] = .string(eventName)
 
     // Only the error type is recorded automatically. The stringified description
     // (`String(describing: error)`) often contains user-supplied data — emails in

--- a/Sources/App/AppLogMetadata.swift
+++ b/Sources/App/AppLogMetadata.swift
@@ -3,6 +3,7 @@ import Crypto
 import Foundation
 import Logging
 
+// swift-log metadata helpers shared by OTel logs and Cloud Run stdout logs.
 enum AppLogMetadata {
   static func make(
     eventName: String,
@@ -77,6 +78,115 @@ enum AppLogMetadata {
   }
 }
 
+enum AppStructuredLog {
+  static func emit(
+    level: Logger.Level,
+    eventName: String,
+    message: Logger.Message,
+    metadata: Logger.Metadata
+  ) {
+    guard let data = makeLineData(
+      level: level,
+      eventName: eventName,
+      message: message,
+      metadata: metadata
+    ) else {
+      return
+    }
+
+    FileHandle.standardOutput.write(data)
+  }
+
+  static func makeRecord(
+    level: Logger.Level,
+    eventName: String,
+    message: Logger.Message,
+    metadata: Logger.Metadata
+  ) -> [String: Any] {
+    var record: [String: Any] = [
+      "severity": cloudLoggingSeverity(for: level),
+      "message": message.description,
+      "eventName": eventName,
+      "metadata": jsonObject(from: metadata),
+    ]
+
+    if let errorType = stringValue(metadata["error.type"]) {
+      record["error"] = ["type": errorType]
+    }
+
+    return record
+  }
+
+  private static func makeLineData(
+    level: Logger.Level,
+    eventName: String,
+    message: Logger.Message,
+    metadata: Logger.Metadata
+  ) -> Data? {
+    let record = makeRecord(
+      level: level,
+      eventName: eventName,
+      message: message,
+      metadata: metadata
+    )
+
+    guard JSONSerialization.isValidJSONObject(record),
+      let data = try? JSONSerialization.data(withJSONObject: record, options: [.sortedKeys])
+    else {
+      return nil
+    }
+
+    var line = data
+    line.append(0x0a)
+    return line
+  }
+
+  private static func jsonObject(from metadata: Logger.Metadata) -> [String: Any] {
+    metadata.reduce(into: [:]) { result, element in
+      result[element.key] = jsonValue(from: element.value)
+    }
+  }
+
+  private static func jsonValue(from value: Logger.Metadata.Value) -> Any {
+    switch value {
+    case .string(let string):
+      return string
+    case .stringConvertible(let value):
+      return value.description
+    case .array(let values):
+      return values.map(jsonValue(from:))
+    case .dictionary(let metadata):
+      return jsonObject(from: metadata)
+    }
+  }
+
+  private static func stringValue(_ value: Logger.Metadata.Value?) -> String? {
+    guard case .string(let string) = value else {
+      return nil
+    }
+    return string
+  }
+
+  private static func cloudLoggingSeverity(for level: Logger.Level) -> String {
+    switch level {
+    case .trace:
+      return "DEBUG"
+    case .debug:
+      return "DEBUG"
+    case .info:
+      return "INFO"
+    case .notice:
+      return "NOTICE"
+    case .warning:
+      return "WARNING"
+    case .error:
+      return "ERROR"
+    case .critical:
+      return "CRITICAL"
+    }
+  }
+}
+
 extension Logger {
   func appLog(
     level: Logger.Level,
@@ -85,14 +195,23 @@ extension Logger {
     metadata: Logger.Metadata = [:],
     error: (any Error)? = nil
   ) {
+    let metadata = AppLogMetadata.make(
+      eventName: eventName,
+      metadata: metadata,
+      error: error
+    )
+
+    AppStructuredLog.emit(
+      level: level,
+      eventName: eventName,
+      message: message,
+      metadata: metadata
+    )
+
     self.log(
       level: level,
       message,
-      metadata: AppLogMetadata.make(
-        eventName: eventName,
-        metadata: metadata,
-        error: error
-      )
+      metadata: metadata
     )
   }
 

--- a/Sources/App/AppLogMetadata.swift
+++ b/Sources/App/AppLogMetadata.swift
@@ -21,7 +21,6 @@ enum AppLogMetadata {
     if let error {
       let errorType = String(reflecting: Swift.type(of: error))
       metadata["error.type"] = .string(errorType)
-      metadata["errorType"] = .string(errorType)
     }
 
     return metadata

--- a/Sources/App/AppLogMetadata.swift
+++ b/Sources/App/AppLogMetadata.swift
@@ -3,7 +3,7 @@ import Crypto
 import Foundation
 import Logging
 
-// swift-log metadata helpers shared by OTel logs and Cloud Run stdout logs.
+// swift-log metadata helpers shared by application logs.
 enum AppLogMetadata {
   static func make(
     eventName: String,
@@ -12,6 +12,7 @@ enum AppLogMetadata {
   ) -> Logger.Metadata {
     var metadata = sanitized(metadata)
     metadata["event.name"] = .string(eventName)
+    metadata["eventName"] = .string(eventName)
 
     // Only the error type is recorded automatically. The stringified description
     // (`String(describing: error)`) often contains user-supplied data — emails in
@@ -19,7 +20,9 @@ enum AppLogMetadata {
     // key-based sanitization here. Call sites that need extra context should
     // pass safe, structured fields via the `metadata` parameter.
     if let error {
-      metadata["error.type"] = .string(String(reflecting: Swift.type(of: error)))
+      let errorType = String(reflecting: Swift.type(of: error))
+      metadata["error.type"] = .string(errorType)
+      metadata["errorType"] = .string(errorType)
     }
 
     return metadata
@@ -78,117 +81,6 @@ enum AppLogMetadata {
   }
 }
 
-enum AppStructuredLog {
-  static func emit(
-    level: Logger.Level,
-    eventName: String,
-    message: Logger.Message,
-    metadata: Logger.Metadata
-  ) {
-    guard
-      let data = makeLineData(
-        level: level,
-        eventName: eventName,
-        message: message,
-        metadata: metadata
-      )
-    else {
-      return
-    }
-
-    FileHandle.standardOutput.write(data)
-  }
-
-  static func makeRecord(
-    level: Logger.Level,
-    eventName: String,
-    message: Logger.Message,
-    metadata: Logger.Metadata
-  ) -> [String: Any] {
-    var record: [String: Any] = [
-      "severity": cloudLoggingSeverity(for: level),
-      "message": message.description,
-      "eventName": eventName,
-      "metadata": jsonObject(from: metadata),
-    ]
-
-    if let errorType = stringValue(metadata["error.type"]) {
-      record["error"] = ["type": errorType]
-    }
-
-    return record
-  }
-
-  private static func makeLineData(
-    level: Logger.Level,
-    eventName: String,
-    message: Logger.Message,
-    metadata: Logger.Metadata
-  ) -> Data? {
-    let record = makeRecord(
-      level: level,
-      eventName: eventName,
-      message: message,
-      metadata: metadata
-    )
-
-    guard JSONSerialization.isValidJSONObject(record),
-      let data = try? JSONSerialization.data(withJSONObject: record, options: [.sortedKeys])
-    else {
-      return nil
-    }
-
-    var line = data
-    line.append(0x0a)
-    return line
-  }
-
-  private static func jsonObject(from metadata: Logger.Metadata) -> [String: Any] {
-    metadata.reduce(into: [:]) { result, element in
-      result[element.key] = jsonValue(from: element.value)
-    }
-  }
-
-  private static func jsonValue(from value: Logger.Metadata.Value) -> Any {
-    switch value {
-    case .string(let string):
-      return string
-    case .stringConvertible(let value):
-      return value.description
-    case .array(let values):
-      return values.map(jsonValue(from:))
-    case .dictionary(let metadata):
-      return jsonObject(from: metadata)
-    }
-  }
-
-  private static func stringValue(_ value: Logger.Metadata.Value?) -> String? {
-    guard case .string(let string) = value else {
-      return nil
-    }
-    return string
-  }
-
-  private static func cloudLoggingSeverity(for level: Logger.Level) -> String {
-    switch level {
-    case .trace:
-      return "DEBUG"
-    case .debug:
-      return "DEBUG"
-    case .info:
-      return "INFO"
-    case .notice:
-      return "NOTICE"
-    case .warning:
-      return "WARNING"
-    case .error:
-      return "ERROR"
-    case .critical:
-      return "CRITICAL"
-    }
-  }
-}
-
 extension Logger {
   func appLog(
     level: Logger.Level,
@@ -197,23 +89,14 @@ extension Logger {
     metadata: Logger.Metadata = [:],
     error: (any Error)? = nil
   ) {
-    let metadata = AppLogMetadata.make(
-      eventName: eventName,
-      metadata: metadata,
-      error: error
-    )
-
-    AppStructuredLog.emit(
-      level: level,
-      eventName: eventName,
-      message: message,
-      metadata: metadata
-    )
-
     self.log(
       level: level,
       message,
-      metadata: metadata
+      metadata: AppLogMetadata.make(
+        eventName: eventName,
+        metadata: metadata,
+        error: error
+      )
     )
   }
 

--- a/Sources/App/AppLogMetadata.swift
+++ b/Sources/App/AppLogMetadata.swift
@@ -85,12 +85,14 @@ enum AppStructuredLog {
     message: Logger.Message,
     metadata: Logger.Metadata
   ) {
-    guard let data = makeLineData(
-      level: level,
-      eventName: eventName,
-      message: message,
-      metadata: metadata
-    ) else {
+    guard
+      let data = makeLineData(
+        level: level,
+        eventName: eventName,
+        message: message,
+        metadata: metadata
+      )
+    else {
       return
     }
 

--- a/Tests/AppTests/ObservabilityTests.swift
+++ b/Tests/AppTests/ObservabilityTests.swift
@@ -68,7 +68,6 @@ struct ObservabilityTests {
     #expect(metadata["user.email"] == nil)
 
     #expect(stringValue(metadata["event.name"]) == "test.event")
-    #expect(stringValue(metadata["eventName"]) == "test.event")
     #expect(stringValue(metadata["db.operation"]) == "select")
     #expect(stringValue(metadata["email.sha256"]) == "safe-hash")
     #expect(stringValue(metadata["user.id"]) == "user-123")

--- a/Tests/AppTests/ObservabilityTests.swift
+++ b/Tests/AppTests/ObservabilityTests.swift
@@ -1,5 +1,4 @@
 import Configuration
-import Foundation
 import Logging
 import OTel
 import Testing
@@ -69,6 +68,7 @@ struct ObservabilityTests {
     #expect(metadata["user.email"] == nil)
 
     #expect(stringValue(metadata["event.name"]) == "test.event")
+    #expect(stringValue(metadata["eventName"]) == "test.event")
     #expect(stringValue(metadata["db.operation"]) == "select")
     #expect(stringValue(metadata["email.sha256"]) == "safe-hash")
     #expect(stringValue(metadata["user.id"]) == "user-123")
@@ -76,40 +76,7 @@ struct ObservabilityTests {
     // stringified error description (which can contain user data).
     #expect(metadata["error.message"] == nil)
     #expect(stringValue(metadata["error.type"])?.contains("TestLogError") == true)
-  }
-
-  @Test
-  func structuredLogRecordKeepsCloudLoggingFieldsAndSanitizesMetadata() throws {
-    let metadata = AppLogMetadata.make(
-      eventName: "auth.passkey.registration_validate_failed",
-      metadata: [
-        "credential": "raw-credential",
-        "db.operation": "select",
-        "user.id": "user-123",
-      ],
-      error: TestLogError.example
-    )
-
-    let record = AppStructuredLog.makeRecord(
-      level: .error,
-      eventName: "auth.passkey.registration_validate_failed",
-      message: "Failed to validate WebAuthn registration",
-      metadata: metadata
-    )
-
-    #expect(record["severity"] as? String == "ERROR")
-    #expect(record["eventName"] as? String == "auth.passkey.registration_validate_failed")
-    #expect(record["message"] as? String == "Failed to validate WebAuthn registration")
-
-    let recordMetadata = try #require(record["metadata"] as? [String: Any])
-    #expect(recordMetadata["credential"] == nil)
-    #expect(recordMetadata["db.operation"] as? String == "select")
-    #expect(recordMetadata["user.id"] as? String == "user-123")
-    #expect(recordMetadata["event.name"] as? String == "auth.passkey.registration_validate_failed")
-
-    let error = try #require(record["error"] as? [String: String])
-    #expect(error["type"]?.contains("TestLogError") == true)
-    #expect(JSONSerialization.isValidJSONObject(record))
+    #expect(stringValue(metadata["errorType"])?.contains("TestLogError") == true)
   }
 
   @Test

--- a/Tests/AppTests/ObservabilityTests.swift
+++ b/Tests/AppTests/ObservabilityTests.swift
@@ -75,7 +75,6 @@ struct ObservabilityTests {
     // stringified error description (which can contain user data).
     #expect(metadata["error.message"] == nil)
     #expect(stringValue(metadata["error.type"])?.contains("TestLogError") == true)
-    #expect(stringValue(metadata["errorType"])?.contains("TestLogError") == true)
   }
 
   @Test

--- a/Tests/AppTests/ObservabilityTests.swift
+++ b/Tests/AppTests/ObservabilityTests.swift
@@ -1,4 +1,5 @@
 import Configuration
+import Foundation
 import Logging
 import OTel
 import Testing
@@ -75,6 +76,40 @@ struct ObservabilityTests {
     // stringified error description (which can contain user data).
     #expect(metadata["error.message"] == nil)
     #expect(stringValue(metadata["error.type"])?.contains("TestLogError") == true)
+  }
+
+  @Test
+  func structuredLogRecordKeepsCloudLoggingFieldsAndSanitizesMetadata() throws {
+    let metadata = AppLogMetadata.make(
+      eventName: "auth.passkey.registration_validate_failed",
+      metadata: [
+        "credential": "raw-credential",
+        "db.operation": "select",
+        "user.id": "user-123",
+      ],
+      error: TestLogError.example
+    )
+
+    let record = AppStructuredLog.makeRecord(
+      level: .error,
+      eventName: "auth.passkey.registration_validate_failed",
+      message: "Failed to validate WebAuthn registration",
+      metadata: metadata
+    )
+
+    #expect(record["severity"] as? String == "ERROR")
+    #expect(record["eventName"] as? String == "auth.passkey.registration_validate_failed")
+    #expect(record["message"] as? String == "Failed to validate WebAuthn registration")
+
+    let recordMetadata = try #require(record["metadata"] as? [String: Any])
+    #expect(recordMetadata["credential"] == nil)
+    #expect(recordMetadata["db.operation"] as? String == "select")
+    #expect(recordMetadata["user.id"] as? String == "user-123")
+    #expect(recordMetadata["event.name"] as? String == "auth.passkey.registration_validate_failed")
+
+    let error = try #require(record["error"] as? [String: String])
+    #expect(error["type"]?.contains("TestLogError") == true)
+    #expect(JSONSerialization.isValidJSONObject(record))
   }
 
   @Test


### PR DESCRIPTION
## 概要

Cloud Run の Cloud Logging でアプリケーションログを検索しやすくするため、`appLog` / `appError` が既存の OTel ログへ渡す metadata を整備します。

stdout への独自 JSON 出力は行わず、ログ出力経路は OTel / swift-log に寄せます。これにより、Cloud Run の標準 stdout ログと OTel logs の二重出力を避けつつ、`eventName` や `errorType` で passkey 登録失敗などのアプリケーションイベントを追いやすくします。

Fixes #299

## 変更内容

- `AppLogMetadata.make` で `eventName` を追加
- 既存の `event.name` は維持
- error が渡された場合に `errorType` を追加
- 既存の `error.type` は維持
- `email` / `token` / `challenge` / `credential` / `body` などの機密 metadata を引き続き除外
- OTel metadata の生成を `ObservabilityTests` で検証

## 確認

- `git diff --check`
- `swift test --package-path /Users/zunda/Documents/GitHub/BlindLog/blindlog-api --filter ObservabilityTests --disable-sandbox`
