### PR TITLE
API の 400/401/404 レスポンスに構造化エラー本文を返す

### DIFF
--- a/Sources/App/API/APIErrorResponses.swift
+++ b/Sources/App/API/APIErrorResponses.swift
@@ -1,0 +1,415 @@
+import Foundation
+
+enum APIErrorCode: String, Sendable {
+  case badRequest = "bad_request"
+  case unauthorized
+  case notFound = "not_found"
+
+  case invalidRequest = "invalid_request"
+  case challengeVerifyFailed = "challenge_verify_failed"
+  case credentialAlreadyExists = "credential_already_exists"
+  case persistFailed = "persist_failed"
+  case registrationDecodeFailed = "registration_decode_failed"
+  case registrationValidateFailed = "registration_validate_failed"
+}
+
+private enum APIErrorResponseFactory {
+  static func make(_ code: APIErrorCode, message: String? = nil) -> Components.Schemas.APIError {
+    Components.Schemas.APIError(error: code.rawValue, message: message)
+  }
+}
+
+extension Operations.AddPasskey.Output {
+  static var badRequest: Self { badRequest(.badRequest) }
+  static func badRequest(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .badRequest(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+  static var unauthorized: Self { unauthorized(.unauthorized) }
+  static func unauthorized(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .unauthorized(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+}
+
+extension Operations.ConfirmEmail.Output {
+  static var badRequest: Self { badRequest(.badRequest) }
+  static func badRequest(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .badRequest(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+  static var unauthorized: Self { unauthorized(.unauthorized) }
+  static func unauthorized(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .unauthorized(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+}
+
+extension Operations.CreateChallenge.Output {
+  static var badRequest: Self { badRequest(.badRequest) }
+  static func badRequest(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .badRequest(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+}
+
+extension Operations.CreateEvent.Output {
+  static var badRequest: Self { badRequest(.badRequest) }
+  static func badRequest(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .badRequest(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+  static var unauthorized: Self { unauthorized(.unauthorized) }
+  static func unauthorized(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .unauthorized(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+}
+
+extension Operations.CreateEventQuestion.Output {
+  static var badRequest: Self { badRequest(.badRequest) }
+  static func badRequest(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .badRequest(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+  static var notFound: Self { notFound(.notFound) }
+  static func notFound(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .notFound(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+  static var unauthorized: Self { unauthorized(.unauthorized) }
+  static func unauthorized(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .unauthorized(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+}
+
+extension Operations.CreateEventQuestionCorrectAnswer.Output {
+  static var badRequest: Self { badRequest(.badRequest) }
+  static func badRequest(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .badRequest(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+  static var notFound: Self { notFound(.notFound) }
+  static func notFound(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .notFound(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+  static var unauthorized: Self { unauthorized(.unauthorized) }
+  static func unauthorized(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .unauthorized(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+}
+
+extension Operations.CreateEventQuestionResponse.Output {
+  static var badRequest: Self { badRequest(.badRequest) }
+  static func badRequest(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .badRequest(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+  static var notFound: Self { notFound(.notFound) }
+  static func notFound(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .notFound(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+  static var unauthorized: Self { unauthorized(.unauthorized) }
+  static func unauthorized(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .unauthorized(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+}
+
+extension Operations.CreateImage.Output {
+  static var badRequest: Self { badRequest(.badRequest) }
+  static func badRequest(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .badRequest(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+  static var unauthorized: Self { unauthorized(.unauthorized) }
+  static func unauthorized(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .unauthorized(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+}
+
+extension Operations.CreateImageUploadURL.Output {
+  static var badRequest: Self { badRequest(.badRequest) }
+  static func badRequest(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .badRequest(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+  static var unauthorized: Self { unauthorized(.unauthorized) }
+  static func unauthorized(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .unauthorized(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+}
+
+extension Operations.CreateTokenFromEmail.Output {
+  static var badRequest: Self { badRequest(.badRequest) }
+  static func badRequest(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .badRequest(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+  static var notFound: Self { notFound(.notFound) }
+  static func notFound(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .notFound(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+  static var unauthorized: Self { unauthorized(.unauthorized) }
+  static func unauthorized(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .unauthorized(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+}
+
+extension Operations.CreateTokenFromPasskey.Output {
+  static var badRequest: Self { badRequest(.badRequest) }
+  static func badRequest(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .badRequest(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+}
+
+extension Operations.CreateUser.Output {
+  static var badRequest: Self { badRequest(.badRequest) }
+  static func badRequest(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .badRequest(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+}
+
+extension Operations.CreateUserProfile.Output {
+  static var badRequest: Self { badRequest(.badRequest) }
+  static func badRequest(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .badRequest(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+  static var unauthorized: Self { unauthorized(.unauthorized) }
+  static func unauthorized(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .unauthorized(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+}
+
+extension Operations.GetEvent.Output {
+  static var badRequest: Self { badRequest(.badRequest) }
+  static func badRequest(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .badRequest(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+  static var notFound: Self { notFound(.notFound) }
+  static func notFound(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .notFound(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+  static var unauthorized: Self { unauthorized(.unauthorized) }
+  static func unauthorized(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .unauthorized(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+}
+
+extension Operations.GetEvents.Output {
+  static var badRequest: Self { badRequest(.badRequest) }
+  static func badRequest(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .badRequest(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+  static var unauthorized: Self { unauthorized(.unauthorized) }
+  static func unauthorized(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .unauthorized(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+}
+
+extension Operations.GetMe.Output {
+  static var badRequest: Self { badRequest(.badRequest) }
+  static func badRequest(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .badRequest(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+  static var unauthorized: Self { unauthorized(.unauthorized) }
+  static func unauthorized(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .unauthorized(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+}
+
+extension Operations.GetUserOrganizedEvents.Output {
+  static var badRequest: Self { badRequest(.badRequest) }
+  static func badRequest(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .badRequest(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+  static var unauthorized: Self { unauthorized(.unauthorized) }
+  static func unauthorized(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .unauthorized(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+}
+
+extension Operations.GetUserParticipatingEvents.Output {
+  static var badRequest: Self { badRequest(.badRequest) }
+  static func badRequest(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .badRequest(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+  static var unauthorized: Self { unauthorized(.unauthorized) }
+  static func unauthorized(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .unauthorized(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+}
+
+extension Operations.GetUserProfile.Output {
+  static var badRequest: Self { badRequest(.badRequest) }
+  static func badRequest(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .badRequest(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+  static var notFound: Self { notFound(.notFound) }
+  static func notFound(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .notFound(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+  static var unauthorized: Self { unauthorized(.unauthorized) }
+  static func unauthorized(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .unauthorized(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+}
+
+extension Operations.GetUsers.Output {
+  static var badRequest: Self { badRequest(.badRequest) }
+  static func badRequest(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .badRequest(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+}
+
+extension Operations.GetWineRegionTypes.Output {
+  static var badRequest: Self { badRequest(.badRequest) }
+  static func badRequest(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .badRequest(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+  static var unauthorized: Self { unauthorized(.unauthorized) }
+  static func unauthorized(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .unauthorized(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+}
+
+extension Operations.GetWineRegions.Output {
+  static var badRequest: Self { badRequest(.badRequest) }
+  static func badRequest(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .badRequest(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+  static var unauthorized: Self { unauthorized(.unauthorized) }
+  static func unauthorized(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .unauthorized(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+}
+
+extension Operations.GetWineStyles.Output {
+  static var badRequest: Self { badRequest(.badRequest) }
+  static func badRequest(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .badRequest(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+  static var unauthorized: Self { unauthorized(.unauthorized) }
+  static func unauthorized(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .unauthorized(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+}
+
+extension Operations.GetWineVarieties.Output {
+  static var badRequest: Self { badRequest(.badRequest) }
+  static func badRequest(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .badRequest(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+  static var unauthorized: Self { unauthorized(.unauthorized) }
+  static func unauthorized(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .unauthorized(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+}
+
+extension Operations.RefreshToken.Output {
+  static var badRequest: Self { badRequest(.badRequest) }
+  static func badRequest(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .badRequest(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+  static var unauthorized: Self { unauthorized(.unauthorized) }
+  static func unauthorized(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .unauthorized(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+}
+
+extension Operations.RegisterEventParticipant.Output {
+  static var badRequest: Self { badRequest(.badRequest) }
+  static func badRequest(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .badRequest(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+  static var notFound: Self { notFound(.notFound) }
+  static func notFound(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .notFound(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+  static var unauthorized: Self { unauthorized(.unauthorized) }
+  static func unauthorized(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .unauthorized(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+}
+
+extension Operations.RevokeToken.Output {
+  static var badRequest: Self { badRequest(.badRequest) }
+  static func badRequest(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .badRequest(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+  static var unauthorized: Self { unauthorized(.unauthorized) }
+  static func unauthorized(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .unauthorized(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+}
+
+extension Operations.SendConfirmEmail.Output {
+  static var badRequest: Self { badRequest(.badRequest) }
+  static func badRequest(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .badRequest(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+  static var unauthorized: Self { unauthorized(.unauthorized) }
+  static func unauthorized(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .unauthorized(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+}
+
+extension Operations.SendEmailForToken.Output {
+  static var badRequest: Self { badRequest(.badRequest) }
+  static func badRequest(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .badRequest(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+  static var notFound: Self { notFound(.notFound) }
+  static func notFound(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .notFound(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+  static var unauthorized: Self { unauthorized(.unauthorized) }
+  static func unauthorized(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .unauthorized(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+}
+
+extension Operations.UpdateEvent.Output {
+  static var badRequest: Self { badRequest(.badRequest) }
+  static func badRequest(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .badRequest(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+  static var notFound: Self { notFound(.notFound) }
+  static func notFound(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .notFound(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+  static var unauthorized: Self { unauthorized(.unauthorized) }
+  static func unauthorized(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .unauthorized(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+}
+
+extension Operations.UpdateEventQuestion.Output {
+  static var badRequest: Self { badRequest(.badRequest) }
+  static func badRequest(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .badRequest(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+  static var notFound: Self { notFound(.notFound) }
+  static func notFound(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .notFound(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+  static var unauthorized: Self { unauthorized(.unauthorized) }
+  static func unauthorized(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .unauthorized(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+}
+
+extension Operations.UpdateEventQuestionCorrectAnswer.Output {
+  static var badRequest: Self { badRequest(.badRequest) }
+  static func badRequest(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .badRequest(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+  static var notFound: Self { notFound(.notFound) }
+  static func notFound(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .notFound(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+  static var unauthorized: Self { unauthorized(.unauthorized) }
+  static func unauthorized(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .unauthorized(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+}
+
+extension Operations.UpdateMyEventQuestionResponse.Output {
+  static var badRequest: Self { badRequest(.badRequest) }
+  static func badRequest(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .badRequest(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+  static var notFound: Self { notFound(.notFound) }
+  static func notFound(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .notFound(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+  static var unauthorized: Self { unauthorized(.unauthorized) }
+  static func unauthorized(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .unauthorized(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+}

--- a/Sources/App/API/Passkey.swift
+++ b/Sources/App/API/Passkey.swift
@@ -20,7 +20,7 @@ extension API {
       throw HTTPError(.tooManyRequests)
     }
     // 1. Parse request payload
-    guard case .json(let body) = input.body else { return .badRequest }
+    guard case .json(let body) = input.body else { return .badRequest(.invalidRequest) }
     let registrationCredential: RegistrationCredential
     do {
       let bodyData = try JSONEncoder().encode(body)
@@ -35,7 +35,7 @@ extension API {
         metadata: AppLogMetadata.userID(userID),
         error: error
       )
-      return .badRequest
+      return .badRequest(.registrationDecodeFailed)
     }
     // 2. Verify and delete challenge atomically
     let challengeData = Data(input.query.challenge.data)
@@ -46,11 +46,23 @@ extension API {
       let challenge = try data.map { try JSONDecoder().decode(Challenge.self, from: Data($0)) }
 
       guard let challenge else {
-        return .badRequest
+        AppRequestContext.current?.logger.appLog(
+          level: .warning,
+          eventName: "auth.passkey.registration_challenge_missing",
+          "Registration challenge was not found",
+          metadata: AppLogMetadata.userID(userID)
+        )
+        return .badRequest(.challengeVerifyFailed)
       }
 
       guard challenge.userID == userID && challenge.purpose == .registration else {
-        return .badRequest
+        AppRequestContext.current?.logger.appLog(
+          level: .warning,
+          eventName: "auth.passkey.registration_challenge_mismatch",
+          "Registration challenge did not match the current user or purpose",
+          metadata: AppLogMetadata.userID(userID)
+        )
+        return .badRequest(.challengeVerifyFailed)
       }
 
     } catch {
@@ -62,7 +74,7 @@ extension API {
         ]) { _, new in new },
         error: error
       )
-      return .badRequest
+      return .badRequest(.challengeVerifyFailed)
     }
 
     // 3. Validate WebAuthn registration data
@@ -82,9 +94,20 @@ extension API {
               .fetchOne(db)
           }
 
-          return credential == nil
+          guard credential == nil else {
+            throw PasskeyRegistrationError.credentialIDAlreadyExists
+          }
+          return true
         }
       )
+    } catch PasskeyRegistrationError.credentialIDAlreadyExists {
+      AppRequestContext.current?.logger.appLog(
+        level: .warning,
+        eventName: "auth.passkey.credential_already_exists",
+        "Passkey credential is already registered",
+        metadata: AppLogMetadata.userID(userID)
+      )
+      return .badRequest(.credentialAlreadyExists)
     } catch {
       AppRequestContext.current?.logger.appError(
         eventName: "auth.passkey.registration_validate_failed",
@@ -92,7 +115,7 @@ extension API {
         metadata: AppLogMetadata.userID(userID),
         error: error
       )
-      return .badRequest
+      return .badRequest(.registrationValidateFailed)
     }
     // 4. Persist credential metadata
     do {
@@ -126,9 +149,13 @@ extension API {
         ]) { _, new in new },
         error: error
       )
-      return .badRequest
+      return .badRequest(.persistFailed)
     }
 
     return .ok
   }
+}
+
+private enum PasskeyRegistrationError: Error {
+  case credentialIDAlreadyExists
 }

--- a/Tests/AppTests/RouterTests.swift
+++ b/Tests/AppTests/RouterTests.swift
@@ -1195,6 +1195,81 @@ struct RouterTests {
   }
 
   @Test
+  func duplicatePasskeyRegistrationReturnsErrorCode() async throws {
+    let arguments = TestArguments()
+    let credentialID = "credential-duplicate"
+    let webAuthn = TestWebAuthn(credentialID: credentialID)
+    let app = try await buildApplication(
+      arguments,
+      cloudflareImagesClient: TestCloudflareImagesClient(),
+      webAuthn: webAuthn
+    )
+    let ipAddress = UUID().uuidString
+
+    try await app.test(.router) { client in
+      let newUserResponse = try await client.execute(
+        uri: "/user",
+        method: .post,
+        headers: [
+          .cfConnectingIP: ipAddress
+        ]
+      )
+      try #require(newUserResponse.status == .ok)
+      let newUser = try JSONDecoder().decode(
+        Components.Schemas.UserToken.self,
+        from: newUserResponse.body
+      )
+      let body = try passkeyRegistrationBody(credentialID: credentialID)
+
+      let firstChallengeResponse = try await client.execute(
+        uri: "/challenge",
+        method: .post,
+        headers: [
+          .cfConnectingIP: ipAddress,
+          .authorization: "Bearer \(newUser.token)",
+        ]
+      )
+      let firstChallenge = try decodedChallenge(from: firstChallengeResponse.body)
+      let firstResponse = try await client.execute(
+        uri: "/passkey?challenge=\(firstChallenge.base64EncodedString())",
+        method: .post,
+        headers: [
+          .cfConnectingIP: ipAddress,
+          .authorization: "Bearer \(newUser.token)",
+        ],
+        body: ByteBuffer(data: body)
+      )
+      #expect(firstResponse.status == .ok)
+
+      let secondChallengeResponse = try await client.execute(
+        uri: "/challenge",
+        method: .post,
+        headers: [
+          .cfConnectingIP: ipAddress,
+          .authorization: "Bearer \(newUser.token)",
+        ]
+      )
+      let secondChallenge = try decodedChallenge(from: secondChallengeResponse.body)
+      let duplicateResponse = try await client.execute(
+        uri: "/passkey?challenge=\(secondChallenge.base64EncodedString())",
+        method: .post,
+        headers: [
+          .cfConnectingIP: ipAddress,
+          .authorization: "Bearer \(newUser.token)",
+        ],
+        body: ByteBuffer(data: body)
+      )
+
+      #expect(duplicateResponse.status == .badRequest)
+      let error = try JSONDecoder().decode(
+        Components.Schemas.APIError.self,
+        from: duplicateResponse.body
+      )
+      #expect(error.error == APIErrorCode.credentialAlreadyExists.rawValue)
+    }
+  }
+
+  @Test
   func sendConfirmEmailAPI() async throws {
     let arguments = TestArguments()
     let app = try await buildApplication(

--- a/public/documents/openapi.yml
+++ b/public/documents/openapi.yml
@@ -62,6 +62,10 @@ paths:
                 contentEncoding: base64
         '400':
           description: A bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
   /passkey:
     post:
       operationId: addPasskey
@@ -90,8 +94,16 @@ paths:
           description: A success response indicating the passkey was registered.
         '400':
           description: A bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
         '401':
           description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
   /user:
     post:
       operationId: createUser
@@ -108,6 +120,10 @@ paths:
                 $ref: '#/components/schemas/UserToken'
         '400':
           description: A bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
   /token/passkey:
     post:
       operationId: createTokenFromPasskey
@@ -130,6 +146,10 @@ paths:
                 $ref: '#/components/schemas/UserToken'
         '400':
           description: A bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
   /token/email:
     post:
       operationId: createTokenFromEmail
@@ -152,10 +172,22 @@ paths:
                 $ref: '#/components/schemas/UserToken'
         '400':
           description: A bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
         '401':
           description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
         '404':
           description: Not found User
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
   /token/email/start:
     post:
       operationId: sendEmailForToken
@@ -181,10 +213,22 @@ paths:
                 contentEncoding: base64
         '400':
           description: A bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
         '401':
           description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
         '404':
           description: Not found User
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
   /refreshToken:
     post:
       operationId: refreshToken
@@ -213,8 +257,16 @@ paths:
                 $ref: '#/components/schemas/UserToken'
         '400':
           description: A bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
         '401':
           description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
   /revokeToken:
     post:
       operationId: revokeToken
@@ -239,8 +291,16 @@ paths:
           description: A success response.
         '400':
           description: A bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
         '401':
           description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
   /me:
     get:
       operationId: getMe
@@ -259,8 +319,16 @@ paths:
                 $ref: '#/components/schemas/Me'
         '400':
           description: A bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
         '401':
           description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
     post:
       operationId: createUserProfile
       tags:
@@ -284,8 +352,16 @@ paths:
                 $ref: '#/components/schemas/UserProfile'
         '400':
           description: A bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
         '401':
           description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
   /user_profile/{user_id}:
     get:
       operationId: getUserProfile
@@ -312,10 +388,22 @@ paths:
                 $ref: '#/components/schemas/UserProfile'
         '400':
           description: A bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
         '401':
           description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
         '404':
           description: Not found User Profile
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
   /users/{user_id}/organized_events:
     get:
       operationId: getUserOrganizedEvents
@@ -344,8 +432,16 @@ paths:
                   $ref: '#/components/schemas/Event'
         '400':
           description: A bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
         '401':
           description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
   /users/{user_id}/participating_events:
     get:
       operationId: getUserParticipatingEvents
@@ -374,8 +470,16 @@ paths:
                   $ref: '#/components/schemas/Event'
         '400':
           description: A bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
         '401':
           description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
   /images/upload_url:
     post:
       operationId: createImageUploadURL
@@ -394,8 +498,16 @@ paths:
                 $ref: '#/components/schemas/CreateImageUploadURLResponse'
         '400':
           description: A bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
         '401':
           description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
   /images:
     post:
       operationId: createImage
@@ -420,8 +532,16 @@ paths:
                 $ref: '#/components/schemas/Image'
         '400':
           description: A bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
         '401':
           description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
   /events:
     get:
       operationId: getEvents
@@ -442,8 +562,16 @@ paths:
                   $ref: '#/components/schemas/Event'
         '400':
           description: A bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
         '401':
           description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
     post:
       operationId: createEvent
       tags:
@@ -467,8 +595,16 @@ paths:
                 $ref: '#/components/schemas/Event'
         '400':
           description: A bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
         '401':
           description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
   /events/{event_id}:
     get:
       operationId: getEvent
@@ -495,10 +631,22 @@ paths:
                 $ref: '#/components/schemas/Event'
         '400':
           description: A bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
         '401':
           description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
         '404':
           description: Not found Event
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
     put:
       operationId: updateEvent
       tags:
@@ -530,10 +678,22 @@ paths:
                 $ref: '#/components/schemas/Event'
         '400':
           description: A bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
         '401':
           description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
         '404':
           description: Not found Event
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
   /events/{event_id}/participants:
     post:
       operationId: registerEventParticipant
@@ -560,10 +720,22 @@ paths:
                 $ref: '#/components/schemas/EventParticipant'
         '400':
           description: A bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
         '401':
           description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
         '404':
           description: Not found Event
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
   /events/{event_id}/questions:
     post:
       operationId: createEventQuestion
@@ -596,10 +768,22 @@ paths:
                 $ref: '#/components/schemas/EventQuestion'
         '400':
           description: A bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
         '401':
           description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
         '404':
           description: Not found Event
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
   /events/{event_id}/questions/{question_id}:
     put:
       operationId: updateEventQuestion
@@ -639,10 +823,22 @@ paths:
                 $ref: '#/components/schemas/EventQuestion'
         '400':
           description: A bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
         '401':
           description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
         '404':
           description: Not found Event Question
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
   /events/{event_id}/questions/{question_id}/correct_answer:
     post:
       operationId: createEventQuestionCorrectAnswer
@@ -682,10 +878,22 @@ paths:
                 $ref: '#/components/schemas/EventQuestionCorrectAnswer'
         '400':
           description: A bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
         '401':
           description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
         '404':
           description: Not found Event Question
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
     put:
       operationId: updateEventQuestionCorrectAnswer
       tags:
@@ -724,10 +932,22 @@ paths:
                 $ref: '#/components/schemas/EventQuestionCorrectAnswer'
         '400':
           description: A bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
         '401':
           description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
         '404':
           description: Not found Event Question
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
   /events/{event_id}/questions/{question_id}/responses:
     post:
       operationId: createEventQuestionResponse
@@ -767,10 +987,22 @@ paths:
                 $ref: '#/components/schemas/EventQuestionResponse'
         '400':
           description: A bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
         '401':
           description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
         '404':
           description: Not found Event Question
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
   /events/{event_id}/questions/{question_id}/responses/me:
     put:
       operationId: updateMyEventQuestionResponse
@@ -810,10 +1042,22 @@ paths:
                 $ref: '#/components/schemas/EventQuestionResponse'
         '400':
           description: A bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
         '401':
           description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
         '404':
           description: Not found Event Question
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
   /wine/styles:
     get:
       operationId: getWineStyles
@@ -834,8 +1078,16 @@ paths:
                   $ref: '#/components/schemas/WineStyle'
         '400':
           description: A bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
         '401':
           description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
   /wine/varieties:
     get:
       operationId: getWineVarieties
@@ -856,8 +1108,16 @@ paths:
                   $ref: '#/components/schemas/WineVariety'
         '400':
           description: A bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
         '401':
           description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
   /wine/region_types:
     get:
       operationId: getWineRegionTypes
@@ -878,8 +1138,16 @@ paths:
                   $ref: '#/components/schemas/WineRegionType'
         '400':
           description: A bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
         '401':
           description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
   /wine/regions:
     get:
       operationId: getWineRegions
@@ -900,8 +1168,16 @@ paths:
                   $ref: '#/components/schemas/WineRegion'
         '400':
           description: A bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
         '401':
           description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
   /users:
     get:
       operationId: getUsers
@@ -931,6 +1207,10 @@ paths:
                   $ref: '#/components/schemas/User'
         '400':
           description: A bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
   /email/verify/start:
     post:
       operationId: sendConfirmEmail
@@ -953,8 +1233,16 @@ paths:
           description: A success response indicating the verification email was sent.
         '400':
           description: A bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
         '401':
           description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
   /email/verify:
     post:
       operationId: confirmEmail
@@ -975,8 +1263,16 @@ paths:
           description: A success response indicating the email address was verified.
         '400':
           description: A bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
         '401':
           description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
 components:
   securitySchemes:
     bearerAuth:
@@ -984,6 +1280,20 @@ components:
       scheme: bearer
       bearerFormat: JWT
   schemas:
+    APIError:
+      type: object
+      description: A machine-readable API error response.
+      properties:
+        error:
+          type: string
+          description: Stable snake_case error code for client-side branching.
+        message:
+          type:
+            - string
+            - 'null'
+          description: Optional safe diagnostic message.
+      required:
+        - error
     UserToken:
       type: object
       description: A value with the User contents.


### PR DESCRIPTION
## 概要

API 全体の `400` / `401` / `404` レスポンスで、クライアントが理由を判別できる JSON エラー本文を返すようにします。

特に `POST /passkey` の既存 credential 再登録では、本文なし 400 ではなく `credential_already_exists` を返すようにして、クライアント側で原因を切り分けられるようにします。

Fixes #298

## 変更内容

- 共通 schema `APIError` を追加
- OpenAPI の `400` / `401` / `404` response に `application/json` error body を定義
- 生成型向けの helper を追加し、既存の `.badRequest` / `.unauthorized` / `.notFound` 呼び出しでも JSON body を返すように変更
- `/passkey` 登録失敗を安定した error code に分類
  - `credential_already_exists`
  - `challenge_verify_failed`
  - `registration_validate_failed`
  - `persist_failed`

## 確認

- `swift build --package-path /Users/zunda/Documents/GitHub/BlindLog/blindlog-api --build-tests --disable-sandbox`

## 補足

`swift test --filter duplicatePasskeyRegistrationReturnsErrorCode --disable-sandbox` は、ローカル設定 `valkey.hostname` がない環境では route assertion 前に停止します。