### PR TITLE
Passkey challenge を Base64URL body 送信に統一する

### DIFF
--- a/Sources/App/API/Base64URL.swift
+++ b/Sources/App/API/Base64URL.swift
@@ -9,6 +9,8 @@ enum Base64URLDecodingError: Error {
 
 extension String {
   func base64URLDecodedBytes() throws -> [UInt8] {
+    // Keep the challenge representation URL-safe itself, instead of relying on
+    // callers to percent-encode standard Base64 when it crosses URL boundaries.
     guard !contains("+") && !contains("/") && !contains("=") else {
       throw Base64URLDecodingError.invalidCharacters
     }

--- a/Sources/App/API/Base64URL.swift
+++ b/Sources/App/API/Base64URL.swift
@@ -1,40 +1,23 @@
+import ExtrasBase64
 import Foundation
-import WebAuthn
 
 enum Base64URLDecodingError: Error {
-  case invalidCharacters
-  case invalidLength
-  case invalidData
+  case paddedValue
 }
 
 extension String {
   func base64URLDecodedBytes() throws -> [UInt8] {
     // Keep the challenge representation URL-safe itself, instead of relying on
     // callers to percent-encode standard Base64 when it crosses URL boundaries.
-    guard !contains("+") && !contains("/") && !contains("=") else {
-      throw Base64URLDecodingError.invalidCharacters
+    guard !contains("=") else {
+      throw Base64URLDecodingError.paddedValue
     }
-
-    let remainder = count % 4
-    guard remainder != 1 else {
-      throw Base64URLDecodingError.invalidLength
-    }
-
-    var base64 = replacingOccurrences(of: "-", with: "+")
-      .replacingOccurrences(of: "_", with: "/")
-    if remainder > 0 {
-      base64 += String(repeating: "=", count: 4 - remainder)
-    }
-
-    guard let data = Data(base64Encoded: base64) else {
-      throw Base64URLDecodingError.invalidData
-    }
-    return Array(data)
+    return try base64decoded(options: [.base64UrlAlphabet, .omitPaddingCharacter])
   }
 }
 
 extension Collection where Element == UInt8 {
   func base64URLEncodedStringValue() -> String {
-    Array(self).base64URLEncodedString().asString()
+    String(base64Encoding: self, options: [.base64UrlAlphabet, .omitPaddingCharacter])
   }
 }

--- a/Sources/App/API/Base64URL.swift
+++ b/Sources/App/API/Base64URL.swift
@@ -1,17 +1,8 @@
 import ExtrasBase64
 import Foundation
 
-enum Base64URLDecodingError: Error {
-  case paddedValue
-}
-
 extension String {
   func base64URLDecodedBytes() throws -> [UInt8] {
-    // Keep the challenge representation URL-safe itself, instead of relying on
-    // callers to percent-encode standard Base64 when it crosses URL boundaries.
-    guard !contains("=") else {
-      throw Base64URLDecodingError.paddedValue
-    }
     return try base64decoded(options: [.base64UrlAlphabet, .omitPaddingCharacter])
   }
 }

--- a/Sources/App/API/Base64URL.swift
+++ b/Sources/App/API/Base64URL.swift
@@ -1,0 +1,38 @@
+import Foundation
+import WebAuthn
+
+enum Base64URLDecodingError: Error {
+  case invalidCharacters
+  case invalidLength
+  case invalidData
+}
+
+extension String {
+  func base64URLDecodedBytes() throws -> [UInt8] {
+    guard !contains("+") && !contains("/") && !contains("=") else {
+      throw Base64URLDecodingError.invalidCharacters
+    }
+
+    let remainder = count % 4
+    guard remainder != 1 else {
+      throw Base64URLDecodingError.invalidLength
+    }
+
+    var base64 = replacingOccurrences(of: "-", with: "+")
+      .replacingOccurrences(of: "_", with: "/")
+    if remainder > 0 {
+      base64 += String(repeating: "=", count: 4 - remainder)
+    }
+
+    guard let data = Data(base64Encoded: base64) else {
+      throw Base64URLDecodingError.invalidData
+    }
+    return Array(data)
+  }
+}
+
+extension Collection where Element == UInt8 {
+  func base64URLEncodedStringValue() -> String {
+    Array(self).base64URLEncodedString().asString()
+  }
+}

--- a/Sources/App/API/CreateChallenge.swift
+++ b/Sources/App/API/CreateChallenge.swift
@@ -72,6 +72,6 @@ extension API {
       return .badRequest
     }
 
-    return .ok(.init(body: .json(.init(challenge))))
+    return .ok(.init(body: .json(challenge.base64URLEncodedStringValue())))
   }
 }

--- a/Sources/App/API/GetTokenFromPasskey.swift
+++ b/Sources/App/API/GetTokenFromPasskey.swift
@@ -1,4 +1,3 @@
-import ExtrasBase64
 import Foundation
 import Hummingbird
 import Records
@@ -41,9 +40,10 @@ extension API {
     }
 
     // 2. Verify and delete challenge atomically
+    let challengeData: [UInt8]
     do {
-      let challengeData = try Data(bodyData.challenge.base64decoded())
-      let key = ValkeyKey("challenge:\(challengeData.base64EncodedString())")
+      challengeData = try bodyData.challenge.base64URLDecodedBytes()
+      let key = ValkeyKey("challenge:\(Data(challengeData).base64EncodedString())")
 
       let data = try await cache.getdel(key)
       let challenge = try data.map { try JSONDecoder().decode(Challenge.self, from: Data($0)) }
@@ -112,7 +112,7 @@ extension API {
     do {
       verifiedAuthentication = try webAuthn.finishAuthentication(
         credential: credential,
-        expectedChallenge: bodyData.challenge.base64decoded(),
+        expectedChallenge: challengeData,
         credentialPublicKey: Array(passkeyCredential.publicKey),
         credentialCurrentSignCount: UInt32(signCount),
         requireUserVerification: false

--- a/Sources/App/API/Passkey.swift
+++ b/Sources/App/API/Passkey.swift
@@ -38,9 +38,21 @@ extension API {
       return .badRequest(.registrationDecodeFailed)
     }
     // 2. Verify and delete challenge atomically
-    let challengeData = Data(input.query.challenge.data)
+    let challengeData: [UInt8]
     do {
-      let key = ValkeyKey("challenge:\(challengeData.base64EncodedString())")
+      challengeData = try body.challenge.base64URLDecodedBytes()
+    } catch {
+      AppRequestContext.current?.logger.appError(
+        eventName: "auth.passkey.registration_challenge_decode_failed",
+        "Failed to decode registration challenge",
+        metadata: AppLogMetadata.userID(userID),
+        error: error
+      )
+      return .badRequest(.challengeVerifyFailed)
+    }
+
+    do {
+      let key = ValkeyKey("challenge:\(Data(challengeData).base64EncodedString())")
 
       let data = try await cache.getdel(key)
       let challenge = try data.map { try JSONDecoder().decode(Challenge.self, from: Data($0)) }
@@ -81,7 +93,7 @@ extension API {
     let credential: Credential
     do {
       credential = try await webAuthn.finishRegistration(
-        challenge: Array(input.query.challenge.data),
+        challenge: challengeData,
         credentialCreationData: registrationCredential,
         requireUserVerification: false,
         supportedPublicKeyAlgorithms: .supported,

--- a/Tests/AppTests/RouterTests.swift
+++ b/Tests/AppTests/RouterTests.swift
@@ -1029,7 +1029,7 @@ struct RouterTests {
       )
 
       #expect(challengeResponse.status == .ok)
-      let challenge = try challengeString(from: challengeResponse.body)
+      let challenge = try JSONDecoder().decode(String.self, from: challengeResponse.body)
       #expect(isBase64URL(challenge))
       #expect(try !challenge.base64URLDecodedBytes().isEmpty)
     }
@@ -1051,7 +1051,7 @@ struct RouterTests {
       )
 
       #expect(response.status == .ok)
-      let challenge = try challengeString(from: response.body)
+      let challenge = try JSONDecoder().decode(String.self, from: response.body)
       #expect(isBase64URL(challenge))
       #expect(try !challenge.base64URLDecodedBytes().isEmpty)
     }
@@ -1088,7 +1088,7 @@ struct RouterTests {
       )
 
       #expect(challengeResponse.status == .ok)
-      let challenge = try challengeString(from: challengeResponse.body)
+      let challenge = try JSONDecoder().decode(String.self, from: challengeResponse.body)
 
       let body = Components.Schemas.AddPasskey(
         challenge: challenge,
@@ -1152,7 +1152,7 @@ struct RouterTests {
         ]
       )
       #expect(registrationChallengeResponse.status == .ok)
-      let registrationChallenge = try challengeString(from: registrationChallengeResponse.body)
+      let registrationChallenge = try JSONDecoder().decode(String.self, from: registrationChallengeResponse.body)
 
       let addPasskeyResponse = try await client.execute(
         uri: "/passkey",
@@ -1177,7 +1177,7 @@ struct RouterTests {
         ]
       )
       #expect(authenticationChallengeResponse.status == .ok)
-      let authenticationChallenge = try challengeString(from: authenticationChallengeResponse.body)
+      let authenticationChallenge = try JSONDecoder().decode(String.self, from: authenticationChallengeResponse.body)
 
       let tokenResponse = try await client.execute(
         uri: "/token/passkey",
@@ -1234,7 +1234,7 @@ struct RouterTests {
           .authorization: "Bearer \(newUser.token)",
         ]
       )
-      let firstChallenge = try challengeString(from: firstChallengeResponse.body)
+      let firstChallenge = try JSONDecoder().decode(String.self, from: firstChallengeResponse.body)
       let firstResponse = try await client.execute(
         uri: "/passkey",
         method: .post,
@@ -1258,7 +1258,7 @@ struct RouterTests {
           .authorization: "Bearer \(newUser.token)",
         ]
       )
-      let secondChallenge = try challengeString(from: secondChallengeResponse.body)
+      let secondChallenge = try JSONDecoder().decode(String.self, from: secondChallengeResponse.body)
       let duplicateResponse = try await client.execute(
         uri: "/passkey",
         method: .post,
@@ -1592,10 +1592,6 @@ private struct TestEmailService: EmailServiceProtocol {
     await recorder?.recordSend(email)
     return EmailResponse.Result(delivered: [], permanentBounces: [], queued: [])
   }
-}
-
-private func challengeString(from body: ByteBuffer) throws -> String {
-  try JSONDecoder().decode(String.self, from: body)
 }
 
 private func isBase64URL(_ value: String) -> Bool {

--- a/Tests/AppTests/RouterTests.swift
+++ b/Tests/AppTests/RouterTests.swift
@@ -1031,7 +1031,7 @@ struct RouterTests {
       #expect(challengeResponse.status == .ok)
       let challenge = try challengeString(from: challengeResponse.body)
       #expect(isBase64URL(challenge))
-      #expect(try !base64URLDecodedBytes(challenge).isEmpty)
+      #expect(try !challenge.base64URLDecodedBytes().isEmpty)
     }
   }
 
@@ -1053,7 +1053,7 @@ struct RouterTests {
       #expect(response.status == .ok)
       let challenge = try challengeString(from: response.body)
       #expect(isBase64URL(challenge))
-      #expect(try !base64URLDecodedBytes(challenge).isEmpty)
+      #expect(try !challenge.base64URLDecodedBytes().isEmpty)
     }
   }
 
@@ -1600,19 +1600,6 @@ private func challengeString(from body: ByteBuffer) throws -> String {
 
 private func isBase64URL(_ value: String) -> Bool {
   !value.contains("+") && !value.contains("/") && !value.contains("=")
-}
-
-private func base64URLDecodedBytes(_ value: String) throws -> [UInt8] {
-  let remainder = value.count % 4
-  try #require(remainder != 1)
-
-  var base64 = value.replacingOccurrences(of: "-", with: "+")
-    .replacingOccurrences(of: "_", with: "/")
-  if remainder > 0 {
-    base64 += String(repeating: "=", count: 4 - remainder)
-  }
-
-  return try Array(#require(Data(base64Encoded: base64)))
 }
 
 private func credentialIDBase64URL(_ credentialID: String) -> String {

--- a/Tests/AppTests/RouterTests.swift
+++ b/Tests/AppTests/RouterTests.swift
@@ -1030,8 +1030,9 @@ struct RouterTests {
 
       #expect(challengeResponse.status == .ok)
       let challenge = try JSONDecoder().decode(String.self, from: challengeResponse.body)
-      #expect(isBase64URL(challenge))
-      #expect(try !challenge.base64URLDecodedBytes().isEmpty)
+      let challengeBytes = try challenge.base64URLDecodedBytes()
+      #expect(!challengeBytes.isEmpty)
+      #expect(challengeBytes.base64URLEncodedStringValue() == challenge)
     }
   }
 
@@ -1052,8 +1053,9 @@ struct RouterTests {
 
       #expect(response.status == .ok)
       let challenge = try JSONDecoder().decode(String.self, from: response.body)
-      #expect(isBase64URL(challenge))
-      #expect(try !challenge.base64URLDecodedBytes().isEmpty)
+      let challengeBytes = try challenge.base64URLDecodedBytes()
+      #expect(!challengeBytes.isEmpty)
+      #expect(challengeBytes.base64URLEncodedStringValue() == challenge)
     }
   }
 
@@ -1601,10 +1603,6 @@ private struct TestEmailService: EmailServiceProtocol {
     await recorder?.recordSend(email)
     return EmailResponse.Result(delivered: [], permanentBounces: [], queued: [])
   }
-}
-
-private func isBase64URL(_ value: String) -> Bool {
-  !value.contains("+") && !value.contains("/") && !value.contains("=")
 }
 
 private func credentialIDBase64URL(_ credentialID: String) -> String {

--- a/Tests/AppTests/RouterTests.swift
+++ b/Tests/AppTests/RouterTests.swift
@@ -1088,7 +1088,10 @@ struct RouterTests {
       )
 
       #expect(challengeResponse.status == .ok)
-      let challenge = try JSONDecoder().decode(String.self, from: challengeResponse.body)
+      let challenge = try JSONDecoder().decode(
+        String.self,
+        from: challengeResponse.body
+      )
 
       let body = Components.Schemas.AddPasskey(
         challenge: challenge,
@@ -1152,7 +1155,10 @@ struct RouterTests {
         ]
       )
       #expect(registrationChallengeResponse.status == .ok)
-      let registrationChallenge = try JSONDecoder().decode(String.self, from: registrationChallengeResponse.body)
+      let registrationChallenge = try JSONDecoder().decode(
+        String.self,
+        from: registrationChallengeResponse.body
+      )
 
       let addPasskeyResponse = try await client.execute(
         uri: "/passkey",
@@ -1177,7 +1183,10 @@ struct RouterTests {
         ]
       )
       #expect(authenticationChallengeResponse.status == .ok)
-      let authenticationChallenge = try JSONDecoder().decode(String.self, from: authenticationChallengeResponse.body)
+      let authenticationChallenge = try JSONDecoder().decode(
+        String.self,
+        from: authenticationChallengeResponse.body
+      )
 
       let tokenResponse = try await client.execute(
         uri: "/token/passkey",

--- a/Tests/AppTests/RouterTests.swift
+++ b/Tests/AppTests/RouterTests.swift
@@ -1245,7 +1245,10 @@ struct RouterTests {
           .authorization: "Bearer \(newUser.token)",
         ]
       )
-      let firstChallenge = try JSONDecoder().decode(String.self, from: firstChallengeResponse.body)
+      let firstChallenge = try JSONDecoder().decode(
+        String.self,
+        from: firstChallengeResponse.body
+      )
       let firstResponse = try await client.execute(
         uri: "/passkey",
         method: .post,
@@ -1269,7 +1272,10 @@ struct RouterTests {
           .authorization: "Bearer \(newUser.token)",
         ]
       )
-      let secondChallenge = try JSONDecoder().decode(String.self, from: secondChallengeResponse.body)
+      let secondChallenge = try JSONDecoder().decode(
+        String.self,
+        from: secondChallengeResponse.body
+      )
       let duplicateResponse = try await client.execute(
         uri: "/passkey",
         method: .post,

--- a/Tests/AppTests/RouterTests.swift
+++ b/Tests/AppTests/RouterTests.swift
@@ -1029,8 +1029,9 @@ struct RouterTests {
       )
 
       #expect(challengeResponse.status == .ok)
-      let challenge = Data(buffer: challengeResponse.body)
-      print(challenge)
+      let challenge = try challengeString(from: challengeResponse.body)
+      #expect(isBase64URL(challenge))
+      #expect(try !base64URLDecodedBytes(challenge).isEmpty)
     }
   }
 
@@ -1050,8 +1051,9 @@ struct RouterTests {
       )
 
       #expect(response.status == .ok)
-      let challenge = Data(buffer: response.body)
-      print(challenge)
+      let challenge = try challengeString(from: response.body)
+      #expect(isBase64URL(challenge))
+      #expect(try !base64URLDecodedBytes(challenge).isEmpty)
     }
   }
 
@@ -1086,9 +1088,10 @@ struct RouterTests {
       )
 
       #expect(challengeResponse.status == .ok)
-      let challenge = try #require(Data(base64Encoded: String(buffer: challengeResponse.body)))
+      let challenge = try challengeString(from: challengeResponse.body)
 
       let body = Components.Schemas.AddPasskey(
+        challenge: challenge,
         id: .init(),
         rawId: .init(),
         _type: .init(),
@@ -1101,7 +1104,7 @@ struct RouterTests {
       let bodyData = try JSONEncoder().encode(body)
 
       let addPasskeyResponse = try await client.execute(
-        uri: "/passkey?challenge=\(challenge.base64EncodedString())",
+        uri: "/passkey",
         method: .post,
         headers: [
           .cfConnectingIP: ipAddress,
@@ -1149,16 +1152,20 @@ struct RouterTests {
         ]
       )
       #expect(registrationChallengeResponse.status == .ok)
-      let registrationChallenge = try decodedChallenge(from: registrationChallengeResponse.body)
+      let registrationChallenge = try challengeString(from: registrationChallengeResponse.body)
 
       let addPasskeyResponse = try await client.execute(
-        uri: "/passkey?challenge=\(registrationChallenge.base64EncodedString())",
+        uri: "/passkey",
         method: .post,
         headers: [
           .cfConnectingIP: ipAddress,
           .authorization: "Bearer \(newUser.token)",
         ],
-        body: ByteBuffer(data: try passkeyRegistrationBody(credentialID: credentialID))
+        body: ByteBuffer(
+          data: try passkeyRegistrationBody(
+            credentialID: credentialID,
+            challenge: registrationChallenge
+          ))
       )
       #expect(addPasskeyResponse.status == .ok)
 
@@ -1170,7 +1177,7 @@ struct RouterTests {
         ]
       )
       #expect(authenticationChallengeResponse.status == .ok)
-      let authenticationChallenge = try decodedChallenge(from: authenticationChallengeResponse.body)
+      let authenticationChallenge = try challengeString(from: authenticationChallengeResponse.body)
 
       let tokenResponse = try await client.execute(
         uri: "/token/passkey",
@@ -1181,7 +1188,7 @@ struct RouterTests {
         body: ByteBuffer(
           data: try passkeyAuthenticationBody(
             credentialID: credentialID,
-            challenge: authenticationChallenge.base64EncodedString()
+            challenge: authenticationChallenge
           ))
       )
 
@@ -1219,8 +1226,6 @@ struct RouterTests {
         Components.Schemas.UserToken.self,
         from: newUserResponse.body
       )
-      let body = try passkeyRegistrationBody(credentialID: credentialID)
-
       let firstChallengeResponse = try await client.execute(
         uri: "/challenge",
         method: .post,
@@ -1229,15 +1234,19 @@ struct RouterTests {
           .authorization: "Bearer \(newUser.token)",
         ]
       )
-      let firstChallenge = try decodedChallenge(from: firstChallengeResponse.body)
+      let firstChallenge = try challengeString(from: firstChallengeResponse.body)
       let firstResponse = try await client.execute(
-        uri: "/passkey?challenge=\(firstChallenge.base64EncodedString())",
+        uri: "/passkey",
         method: .post,
         headers: [
           .cfConnectingIP: ipAddress,
           .authorization: "Bearer \(newUser.token)",
         ],
-        body: ByteBuffer(data: body)
+        body: ByteBuffer(
+          data: try passkeyRegistrationBody(
+            credentialID: credentialID,
+            challenge: firstChallenge
+          ))
       )
       #expect(firstResponse.status == .ok)
 
@@ -1249,15 +1258,19 @@ struct RouterTests {
           .authorization: "Bearer \(newUser.token)",
         ]
       )
-      let secondChallenge = try decodedChallenge(from: secondChallengeResponse.body)
+      let secondChallenge = try challengeString(from: secondChallengeResponse.body)
       let duplicateResponse = try await client.execute(
-        uri: "/passkey?challenge=\(secondChallenge.base64EncodedString())",
+        uri: "/passkey",
         method: .post,
         headers: [
           .cfConnectingIP: ipAddress,
           .authorization: "Bearer \(newUser.token)",
         ],
-        body: ByteBuffer(data: body)
+        body: ByteBuffer(
+          data: try passkeyRegistrationBody(
+            credentialID: credentialID,
+            challenge: secondChallenge
+          ))
       )
 
       #expect(duplicateResponse.status == .badRequest)
@@ -1581,22 +1594,36 @@ private struct TestEmailService: EmailServiceProtocol {
   }
 }
 
-private func decodedChallenge(from body: ByteBuffer) throws -> Data {
-  if let challenge = Data(base64Encoded: String(buffer: body)) {
-    return challenge
+private func challengeString(from body: ByteBuffer) throws -> String {
+  try JSONDecoder().decode(String.self, from: body)
+}
+
+private func isBase64URL(_ value: String) -> Bool {
+  !value.contains("+") && !value.contains("/") && !value.contains("=")
+}
+
+private func base64URLDecodedBytes(_ value: String) throws -> [UInt8] {
+  let remainder = value.count % 4
+  try #require(remainder != 1)
+
+  var base64 = value.replacingOccurrences(of: "-", with: "+")
+    .replacingOccurrences(of: "_", with: "/")
+  if remainder > 0 {
+    base64 += String(repeating: "=", count: 4 - remainder)
   }
-  let challenge = try JSONDecoder().decode(String.self, from: body)
-  return try #require(Data(base64Encoded: challenge))
+
+  return try Array(#require(Data(base64Encoded: base64)))
 }
 
 private func credentialIDBase64URL(_ credentialID: String) -> String {
   Array(credentialID.utf8).base64URLEncodedString().asString()
 }
 
-private func passkeyRegistrationBody(credentialID: String) throws -> Data {
+private func passkeyRegistrationBody(credentialID: String, challenge: String) throws -> Data {
   let encodedCredentialID = credentialIDBase64URL(credentialID)
   return try JSONEncoder().encode(
     PasskeyRegistrationFixture(
+      challenge: challenge,
       id: encodedCredentialID,
       rawId: encodedCredentialID,
       type: "public-key",
@@ -1624,6 +1651,7 @@ private func passkeyAuthenticationBody(credentialID: String, challenge: String) 
 }
 
 private struct PasskeyRegistrationFixture: Encodable {
+  var challenge: String
   var id: String
   var rawId: String
   var type: String

--- a/public/app.js
+++ b/public/app.js
@@ -1749,12 +1749,12 @@
       },
 
       async registerPasskey({ challenge, payload, token }) {
-        await post(`/passkey?challenge=${encodeURIComponent(challenge)}`, {
+        await post('/passkey', {
           headers: {
             'Content-Type': 'application/json',
             Authorization: `Bearer ${token}`,
           },
-          body: JSON.stringify(payload),
+          body: JSON.stringify({ ...payload, challenge }),
           message: 'Passkey登録に失敗しました。',
         });
       },

--- a/public/documents/openapi.yml
+++ b/public/documents/openapi.yml
@@ -59,7 +59,6 @@ paths:
             application/json:
               schema:
                 type: string
-                contentEncoding: base64
         '400':
           description: A bad request
           content:
@@ -75,14 +74,6 @@ paths:
       description: Registers a new passkey credential for the authenticated user using a challenge previously returned by the API.
       security:
         - bearerAuth: []
-      parameters:
-        - name: challenge
-          in: query
-          description: Base64URL-encoded challenge returned by `POST /challenge` for this passkey registration.
-          required: true
-          schema:
-            type: string
-            contentEncoding: base64
       requestBody:
         required: true
         content:
@@ -2009,6 +2000,9 @@ components:
       type: object
       description: Passkey registration payload from `navigator.credentials.create`.
       properties:
+        challenge:
+          type: string
+          description: Base64URL-encoded challenge issued by the server.
         id:
           type: string
           description: Credential identifier encoded in Base64URL.
@@ -2021,6 +2015,7 @@ components:
         response:
           $ref: '#/components/schemas/AuthenticatorAttestation'
       required:
+        - challenge
         - id
         - rawId
         - type


### PR DESCRIPTION
## 概要

Passkey/WebAuthn の challenge 表現を Base64URL に統一し、`POST /passkey` の challenge を URL query から JSON body へ移します。

標準 Base64 を query に載せると `+`, `/`, `=` の扱いで challenge が壊れる可能性があるため、WebAuthn Level 3 の JSON 表現に合わせて API 上の challenge を Base64URL 文字列として扱います。

Fixes #300

## 変更内容

- `POST /challenge` のレスポンスを Base64URL 文字列に変更
- `POST /passkey?challenge=...` を廃止し、`AddPasskey.challenge` を required body field に追加
- passkey 登録・認証時は Base64URL decode 後の bytes で cache key と WebAuthn 検証を実行
- Base64URL encode/decode は既存依存の `swift-extras-base64` を利用
- OpenAPI から passkey challenge の `contentEncoding: base64` と query parameter を削除
- RouterTests の passkey flow を新しい body 形式に更新

## 破壊的変更

既存クライアントは `POST /passkey?challenge=...` ではなく、JSON body の `challenge` に `/challenge` の戻り値を入れる必要があります。

## 確認

- `swift test --disable-sandbox`
  - App/AppTests のビルド成功
  - テスト実行はローカル設定 `valkey.hostname` 未設定により RouterTests が失敗