### PR TITLE
POST /challenge を目的別パスに分割し登録は要認証にする (#304)

### DIFF
--- a/Sources/App/API/APIErrorResponses.swift
+++ b/Sources/App/API/APIErrorResponses.swift
@@ -41,7 +41,18 @@ extension Operations.ConfirmEmail.Output {
   }
 }
 
-extension Operations.CreateChallenge.Output {
+extension Operations.CreateRegistrationChallenge.Output {
+  static var badRequest: Self { badRequest(.badRequest) }
+  static func badRequest(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .badRequest(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+  static var unauthorized: Self { unauthorized(.unauthorized) }
+  static func unauthorized(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .unauthorized(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+}
+
+extension Operations.CreateAuthenticationChallenge.Output {
   static var badRequest: Self { badRequest(.badRequest) }
   static func badRequest(_ code: APIErrorCode, message: String? = nil) -> Self {
     .badRequest(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))

--- a/Sources/App/API/CreateChallenge.swift
+++ b/Sources/App/API/CreateChallenge.swift
@@ -6,72 +6,101 @@ import Valkey
 import WebAuthn
 
 extension API {
-  func createChallenge(
-    _ input: Operations.CreateChallenge.Input
-  ) async throws -> Operations.CreateChallenge.Output {
-    // 1. Generate Challenge
-    let userID = UserTokenContext.currentUserID
-
-    if userID != nil {
-      guard let userTokenAccessCount = RateLimitContext.userTokenAccessCount,
-        userTokenAccessCount < RateLimitContext.authenticationEndpointMaxCount
-      else {
-        throw HTTPError(.tooManyRequests)
-      }
-    } else {
-      guard let ipAddressCount = RateLimitContext.ipAddressAccessCount,
-        ipAddressCount < RateLimitContext.authenticationEndpointMaxCount
-      else {
-        throw HTTPError(.tooManyRequests)
-      }
+  func createRegistrationChallenge(
+    _ input: Operations.CreateRegistrationChallenge.Input
+  ) async throws -> Operations.CreateRegistrationChallenge.Output {
+    // 1. Registration challenges are always bound to an authenticated user.
+    guard let userID = UserTokenContext.currentUserID else {
+      return .unauthorized
     }
 
-    let challenge: [UInt8] =
-      if let userID {
-        // SignUp
-        webAuthn.beginRegistration(
-          user: .init(
-            id: Array(Data(userID.uuidString.utf8)),
-            name: userID.uuidString,
-            displayName: userID.uuidString
-          ),
-          timeout: .seconds(5 * 60),
-          attestation: .none,
-          publicKeyCredentialParameters: .supported
-        ).challenge
-      } else {
-        webAuthn.beginAuthentication(
-          timeout: .seconds(60),
-          allowCredentials: nil,
-          userVerification: .preferred
-        ).challenge
-      }
+    guard let userTokenAccessCount = RateLimitContext.userTokenAccessCount,
+      userTokenAccessCount < RateLimitContext.authenticationEndpointMaxCount
+    else {
+      throw HTTPError(.tooManyRequests)
+    }
 
-    // 2. Save Challenge to DB with expired date
+    // 2. Generate the challenge.
+    let challenge = webAuthn.beginRegistration(
+      user: .init(
+        id: Array(Data(userID.uuidString.utf8)),
+        name: userID.uuidString,
+        displayName: userID.uuidString
+      ),
+      timeout: .seconds(5 * 60),
+      attestation: .none,
+      publicKeyCredentialParameters: .supported
+    ).challenge
+
+    // 3. Save the challenge with an expiration.
     do {
-      let challenge = Challenge(
-        challenge: Data(challenge),
-        userID: userID,
-        purpose: userID == nil ? .authentication : .registration
-      )
-      try await cache.set(
-        ValkeyKey("challenge:\(challenge.challenge.base64EncodedString())"),
-        value: try JSONEncoder().encode(challenge),
-        expiration: .seconds(60 * 10)  // 10 minutes
-      )
+      try await storeChallenge(challenge, userID: userID, purpose: .registration)
     } catch {
-      AppRequestContext.current?.logger.appError(
-        eventName: "auth.challenge.cache_write_failed",
-        "Failed to save challenge with expiration",
-        metadata: AppLogMetadata.userID(userID).merging([
-          "auth.purpose": .string(userID == nil ? "authentication" : "registration"),
-          "cache.operation": .string("set"),
-        ]) { _, new in new },
-        error: error
-      )
+      logChallengeWriteFailure(userID: userID, purpose: .registration, error: error)
       return .badRequest
     }
 
     return .ok(.init(body: .json(challenge.base64URLEncodedStringValue())))
+  }
+
+  func createAuthenticationChallenge(
+    _ input: Operations.CreateAuthenticationChallenge.Input
+  ) async throws -> Operations.CreateAuthenticationChallenge.Output {
+    // 1. Authentication challenges are not bound to a user, so rate limit by IP.
+    guard let ipAddressAccessCount = RateLimitContext.ipAddressAccessCount,
+      ipAddressAccessCount < RateLimitContext.authenticationEndpointMaxCount
+    else {
+      throw HTTPError(.tooManyRequests)
+    }
+
+    // 2. Generate the challenge.
+    let challenge = webAuthn.beginAuthentication(
+      timeout: .seconds(60),
+      allowCredentials: nil,
+      userVerification: .preferred
+    ).challenge
+
+    // 3. Save the challenge with an expiration.
+    do {
+      try await storeChallenge(challenge, userID: nil, purpose: .authentication)
+    } catch {
+      logChallengeWriteFailure(userID: nil, purpose: .authentication, error: error)
+      return .badRequest
+    }
+
+    return .ok(.init(body: .json(challenge.base64URLEncodedStringValue())))
+  }
+
+  private func storeChallenge(
+    _ challenge: [UInt8],
+    userID: UUID?,
+    purpose: Challenge.Purpose
+  ) async throws {
+    let record = Challenge(
+      challenge: Data(challenge),
+      userID: userID,
+      purpose: purpose
+    )
+    try await cache.set(
+      ValkeyKey("challenge:\(record.challenge.base64EncodedString())"),
+      value: try JSONEncoder().encode(record),
+      expiration: .seconds(60 * 10)  // 10 minutes
+    )
+  }
+
+  private func logChallengeWriteFailure(
+    userID: UUID?,
+    purpose: Challenge.Purpose,
+    error: any Error
+  ) {
+    AppRequestContext.current?.logger.appError(
+      eventName: "auth.challenge.cache_write_failed",
+      "Failed to save challenge with expiration",
+      metadata: AppLogMetadata.userID(userID).merging([
+        "auth.purpose": .string(purpose.rawValue),
+        "cache.operation": .string("set"),
+      ]) { _, new in new },
+      error: error
+    )
   }
 }

--- a/Tests/AppTests/RouterTests.swift
+++ b/Tests/AppTests/RouterTests.swift
@@ -1020,7 +1020,7 @@ struct RouterTests {
       )
       // 2. Get User to DB
       let challengeResponse = try await client.execute(
-        uri: "/challenge",
+        uri: "/challenge/registration",
         method: .post,
         headers: [
           .cfConnectingIP: ipAddress,
@@ -1044,7 +1044,7 @@ struct RouterTests {
 
     try await app.test(.router) { client in
       let response = try await client.execute(
-        uri: "/challenge",
+        uri: "/challenge/authentication",
         method: .post,
         headers: [
           .cfConnectingIP: ipAddress
@@ -1056,6 +1056,25 @@ struct RouterTests {
       let challengeBytes = try challenge.base64URLDecodedBytes()
       #expect(!challengeBytes.isEmpty)
       #expect(challengeBytes.base64URLEncodedStringValue() == challenge)
+    }
+  }
+
+  @Test
+  func registrationChallengeRequiresAuthentication() async throws {
+    let arguments = TestArguments()
+    let app = try await buildApplication(arguments)
+    let ipAddress = UUID().uuidString
+
+    try await app.test(.router) { client in
+      let response = try await client.execute(
+        uri: "/challenge/registration",
+        method: .post,
+        headers: [
+          .cfConnectingIP: ipAddress
+        ]
+      )
+
+      #expect(response.status == .unauthorized)
     }
   }
 
@@ -1081,7 +1100,7 @@ struct RouterTests {
       )
       // 2. Get User to DB
       let challengeResponse = try await client.execute(
-        uri: "/challenge",
+        uri: "/challenge/registration",
         method: .post,
         headers: [
           .cfConnectingIP: ipAddress,
@@ -1149,7 +1168,7 @@ struct RouterTests {
       )
 
       let registrationChallengeResponse = try await client.execute(
-        uri: "/challenge",
+        uri: "/challenge/registration",
         method: .post,
         headers: [
           .cfConnectingIP: ipAddress,
@@ -1178,7 +1197,7 @@ struct RouterTests {
       #expect(addPasskeyResponse.status == .ok)
 
       let authenticationChallengeResponse = try await client.execute(
-        uri: "/challenge",
+        uri: "/challenge/authentication",
         method: .post,
         headers: [
           .cfConnectingIP: ipAddress
@@ -1238,7 +1257,7 @@ struct RouterTests {
         from: newUserResponse.body
       )
       let firstChallengeResponse = try await client.execute(
-        uri: "/challenge",
+        uri: "/challenge/registration",
         method: .post,
         headers: [
           .cfConnectingIP: ipAddress,
@@ -1265,7 +1284,7 @@ struct RouterTests {
       #expect(firstResponse.status == .ok)
 
       let secondChallengeResponse = try await client.execute(
-        uri: "/challenge",
+        uri: "/challenge/registration",
         method: .post,
         headers: [
           .cfConnectingIP: ipAddress,

--- a/public/app.js
+++ b/public/app.js
@@ -329,7 +329,7 @@
         status.set('passkey', 'チャレンジ取得中...');
         status.clear('logout');
         try {
-          const challenge = await api.fetchChallenge({ token });
+          const challenge = await api.fetchRegistrationChallenge({ token });
           const options = webAuthn.buildRegistrationOptions({
             challenge,
             userID,
@@ -359,7 +359,7 @@
         status.set('login', 'チャレンジ取得中...');
         status.clear('logout', 'emailLogin');
         try {
-          const challenge = await api.fetchChallenge();
+          const challenge = await api.fetchAuthenticationChallenge();
           const options = webAuthn.buildAuthenticationOptions(challenge);
           const credential = await navigator.credentials.get({ publicKey: options });
           if (!credential) {
@@ -1739,10 +1739,16 @@
         });
       },
 
-      async fetchChallenge({ token } = {}) {
-        const headers = token ? { Authorization: `Bearer ${token}` } : {};
-        const response = await post('/challenge', {
-          headers,
+      async fetchRegistrationChallenge({ token }) {
+        const response = await post('/challenge/registration', {
+          headers: { Authorization: `Bearer ${token}` },
+          message: 'チャレンジ取得に失敗しました。',
+        });
+        return readChallengeResponse(response);
+      },
+
+      async fetchAuthenticationChallenge() {
+        const response = await post('/challenge/authentication', {
           message: 'チャレンジ取得に失敗しました。',
         });
         return readChallengeResponse(response);

--- a/public/documents/openapi.yml
+++ b/public/documents/openapi.yml
@@ -45,16 +45,50 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AppleAppSiteAssociation'
-  /challenge:
+  /challenge/registration:
     post:
-      operationId: createChallenge
+      operationId: createRegistrationChallenge
       tags:
         - Authentication
-      summary: Create passkey challenge
-      description: Issues a Base64URL-encoded challenge that clients use before registering or authenticating with a passkey.
+      summary: Create passkey registration challenge
+      description: |-
+        Issues a Base64URL-encoded challenge for registering a new passkey.
+        Requires a Bearer token and binds the challenge to the authenticated user.
+        The challenge is single-use (consumed via getdel) and expires after 10 minutes.
+      security:
+        - bearerAuth: []
       responses:
         '200':
-          description: A success response with a newly issued passkey challenge.
+          description: A success response with a newly issued passkey registration challenge.
+          content:
+            application/json:
+              schema:
+                type: string
+        '400':
+          description: A bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+  /challenge/authentication:
+    post:
+      operationId: createAuthenticationChallenge
+      tags:
+        - Authentication
+      summary: Create passkey authentication challenge
+      description: |-
+        Issues a Base64URL-encoded challenge for authenticating with an existing passkey.
+        No authentication is required and the challenge is not bound to a user.
+        The challenge is single-use (consumed via getdel) and expires after 10 minutes.
+      responses:
+        '200':
+          description: A success response with a newly issued passkey authentication challenge.
           content:
             application/json:
               schema:


### PR DESCRIPTION
## 概要

Closes #304

`POST /challenge` が Bearer トークンの有無で registration / authentication を**暗黙に**切り替えていたため、クライアントがトークン無しで登録チャレンジを取得すると authentication チャレンジが返り、登録時に初めて `challenge_verify_failed` になっていた。原因地点が発行時から遠く特定が困難だった。

issue #304 の **path-split 案**を採用し、目的をパスで自己説明的にした。

## 変更内容

- **エンドポイント分割**
  - `POST /challenge/registration` — 要 Bearer 認証。userID に紐付けた registration チャレンジを発行。トークン無しは **401 unauthorized**。
  - `POST /challenge/authentication` — 認証不要。userID=nil の authentication チャレンジを発行。
- **OpenAPI** (`public/documents/openapi.yml`) — registration に `security: bearerAuth` と 401 を明示。各エンドポイントの説明に「base64url / TTL 10分 / 単回 (getdel)」を追記。
- **サーバ** (`CreateChallenge.swift`) — `createRegistrationChallenge` / `createAuthenticationChallenge` の 2 ハンドラに分割。チャレンジ保存は共通ヘルパー化。レート制限は登録=userToken、認証=IP。
- **エラーレスポンス** (`APIErrorResponses.swift`) — 新 operation 用の `.badRequest` / `.unauthorized` ヘルパーを追加。
- **Web クライアント** (`public/app.js`) — `fetchRegistrationChallenge` / `fetchAuthenticationChallenge` に分割し、各フローから呼び分け。
- **テスト** (`RouterTests.swift`) — 既存テストを新パスへ更新。登録チャレンジの要認証 (401) テストを追加。

## 補足

- issue の案 A（purpose パラメータ）ではなく、より自己説明的な **path-split** を選択（ユーザー指定）。
- 案 B（エラー粒度の細分化）は本 PR の対象外。