### PR TITLE
GET /events/{event_id}/questions でイベントの質問一覧を取得する (#306)

### DIFF
--- a/Sources/App/API/APIErrorResponses.swift
+++ b/Sources/App/API/APIErrorResponses.swift
@@ -192,6 +192,21 @@ extension Operations.GetEvent.Output {
   }
 }
 
+extension Operations.GetEventQuestions.Output {
+  static var badRequest: Self { badRequest(.badRequest) }
+  static func badRequest(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .badRequest(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+  static var notFound: Self { notFound(.notFound) }
+  static func notFound(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .notFound(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+  static var unauthorized: Self { unauthorized(.unauthorized) }
+  static func unauthorized(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .unauthorized(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+}
+
 extension Operations.GetEvents.Output {
   static var badRequest: Self { badRequest(.badRequest) }
   static func badRequest(_ code: APIErrorCode, message: String? = nil) -> Self {

--- a/Sources/App/API/Events.swift
+++ b/Sources/App/API/Events.swift
@@ -648,6 +648,36 @@ extension API {
       return .badRequest
     }
   }
+
+  func getEventQuestions(
+    _ input: Operations.GetEventQuestions.Input
+  ) async throws -> Operations.GetEventQuestions.Output {
+    guard let userID = UserTokenContext.currentUserID else {
+      return .unauthorized
+    }
+    guard let eventID = UUID(uuidString: input.path.eventId) else {
+      return .badRequest
+    }
+
+    do {
+      guard let event = try await latestEventSnapshot(eventID: eventID) else {
+        return .notFound
+      }
+      guard try await canViewEvent(event, userID: userID) else {
+        return .notFound
+      }
+      let questions = try await latestEventQuestionSnapshots(eventID: eventID)
+      return .ok(.init(body: .json(questions.map(Components.Schemas.EventQuestion.init))))
+    } catch {
+      logEventDatabaseError(
+        "event.question_list_failed",
+        "Failed to fetch event questions",
+        userID: userID,
+        error: error
+      )
+      return .badRequest
+    }
+  }
 }
 
 extension API {
@@ -1223,6 +1253,30 @@ extension API {
         }
         .limit(1)
         .fetchOne(db)
+    }
+  }
+
+  fileprivate func latestEventQuestionSnapshots(
+    eventID: UUID
+  ) async throws -> [EventQuestionSnapshot] {
+    try await database.read { db in
+      let rows =
+        try await EventQuestionRecord
+        .where { $0.eventID.eq(eventID) }
+        .joinLateral { question in
+          EventQuestionRevisionRecord
+            .where { $0.eventQuestionID.eq(question.id) }
+            .order { ($0.createdAt.desc(), $0.id.desc()) }
+            .limit(1)
+        }
+        .order { question, _ in
+          (question.questionNumber, question.id)
+        }
+        .selectStar()
+        .fetchAll(db)
+      return rows.map { question, revision in
+        EventQuestionSnapshot(question: question, revision: revision)
+      }
     }
   }
 

--- a/public/documents/openapi.yml
+++ b/public/documents/openapi.yml
@@ -762,6 +762,49 @@ paths:
               schema:
                 $ref: '#/components/schemas/APIError'
   /events/{event_id}/questions:
+    get:
+      operationId: getEventQuestions
+      tags:
+        - Events
+      summary: List event questions
+      description: Returns the questions of a blind tasting event ordered by question number.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: event_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: Target event ID in UUID format.
+      responses:
+        '200':
+          description: A success response with the event questions.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/EventQuestion'
+        '400':
+          description: A bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+        '404':
+          description: Not found Event
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
     post:
       operationId: createEventQuestion
       tags:


### PR DESCRIPTION
## 概要
Closes #306

参加者フローのブロッカーになっていた「質問一覧の取得」を追加する。これまで質問は書き込み (POST/PUT) のみで、参加者が出題を閲覧できなかった。

## 変更点
- `GET /events/{event_id}/questions` を追加（openapi.yml）
- ハンドラ `getEventQuestions` を実装（`Sources/App/API/Events.swift`）
  - 各質問は最新リビジョン（`event_question_revisions`）を結合し、`questionNumber` 昇順で返す
  - 既存の `latestEventSnapshot` / `canViewEvent` で閲覧可否を判定
- `APIErrorResponses.swift` に `GetEventQuestions.Output` の便利メンバーを追加

## 認可・エラー
- 主催者・閲覧可能な参加者の双方が取得可能
- 閲覧権限のないイベント / 非公開は **404**
  - ※ issue では権限外を 403/404 と記載していますが、本リポジトリの既存規約（`getEvent` 等）に合わせ **404 に統一**しています

## 受け入れ条件
- [x] 主催者・参加者の双方が質問一覧を取得できる
- [x] 権限外イベントでは 401/404
- [x] openapi.yml に追記

🤖 Generated with [Claude Code](https://claude.com/claude-code)