### PR TITLE
回答・正解の取得 GET エンドポイントを追加する (#307)

### DIFF
--- a/Sources/App/API/APIErrorResponses.swift
+++ b/Sources/App/API/APIErrorResponses.swift
@@ -192,7 +192,37 @@ extension Operations.GetEvent.Output {
   }
 }
 
+extension Operations.GetEventQuestionCorrectAnswer.Output {
+  static var badRequest: Self { badRequest(.badRequest) }
+  static func badRequest(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .badRequest(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+  static var notFound: Self { notFound(.notFound) }
+  static func notFound(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .notFound(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+  static var unauthorized: Self { unauthorized(.unauthorized) }
+  static func unauthorized(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .unauthorized(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+}
+
 extension Operations.GetEventQuestions.Output {
+  static var badRequest: Self { badRequest(.badRequest) }
+  static func badRequest(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .badRequest(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+  static var notFound: Self { notFound(.notFound) }
+  static func notFound(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .notFound(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+  static var unauthorized: Self { unauthorized(.unauthorized) }
+  static func unauthorized(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .unauthorized(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+}
+
+extension Operations.GetEventQuestionResponses.Output {
   static var badRequest: Self { badRequest(.badRequest) }
   static func badRequest(_ code: APIErrorCode, message: String? = nil) -> Self {
     .badRequest(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
@@ -222,6 +252,21 @@ extension Operations.GetMe.Output {
   static var badRequest: Self { badRequest(.badRequest) }
   static func badRequest(_ code: APIErrorCode, message: String? = nil) -> Self {
     .badRequest(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+  static var unauthorized: Self { unauthorized(.unauthorized) }
+  static func unauthorized(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .unauthorized(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+}
+
+extension Operations.GetMyEventQuestionResponse.Output {
+  static var badRequest: Self { badRequest(.badRequest) }
+  static func badRequest(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .badRequest(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+  static var notFound: Self { notFound(.notFound) }
+  static func notFound(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .notFound(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
   }
   static var unauthorized: Self { unauthorized(.unauthorized) }
   static func unauthorized(_ code: APIErrorCode, message: String? = nil) -> Self {

--- a/Sources/App/API/Events.swift
+++ b/Sources/App/API/Events.swift
@@ -696,11 +696,192 @@ extension API {
         return .notFound
       }
       let questions = try await latestEventQuestionSnapshots(eventID: eventID)
-      return .ok(.init(body: .json(questions.map(Components.Schemas.EventQuestion.init))))
+      var questionSchemas: [Components.Schemas.EventQuestion] = []
+      for question in questions {
+        questionSchemas.append(await makeEventQuestion(question))
+      }
+      return .ok(.init(body: .json(questionSchemas)))
     } catch {
       logEventDatabaseError(
         "event.question_list_failed",
         "Failed to fetch event questions",
+        userID: userID,
+        error: error
+      )
+      return .badRequest
+    }
+  }
+
+  func getMyEventQuestionResponse(
+    _ input: Operations.GetMyEventQuestionResponse.Input
+  ) async throws -> Operations.GetMyEventQuestionResponse.Output {
+    guard let userID = UserTokenContext.currentUserID else {
+      return .unauthorized
+    }
+    guard
+      let eventID = UUID(uuidString: input.path.eventId),
+      let questionID = UUID(uuidString: input.path.questionId)
+    else {
+      return .badRequest
+    }
+
+    do {
+      guard try await eventQuestionExists(questionID: questionID, eventID: eventID) else {
+        return .notFound
+      }
+      let result = try await database.read {
+        db -> (EventQuestionResponseRecord, EventQuestionResponseRevisionRecord, [UUID])? in
+        guard
+          let response = try await eventQuestionResponse(
+            questionID: questionID,
+            userID: userID,
+            db: db
+          ),
+          let revision = try await latestResponseRevision(responseID: response.id, db: db)
+        else {
+          return nil
+        }
+        let varietyIDs = try await responseVarietyIDs(revisionID: revision.id, db: db)
+        return (response, revision, varietyIDs)
+      }
+      guard let result else {
+        return .notFound
+      }
+      return .ok(
+        .init(
+          body: .json(
+            .init(response: result.0, revision: result.1, wineVarietyIDs: result.2)
+          )
+        )
+      )
+    } catch {
+      logEventDatabaseError(
+        "event.response_read_failed",
+        "Failed to fetch event response",
+        userID: userID,
+        error: error
+      )
+      return .badRequest
+    }
+  }
+
+  func getEventQuestionResponses(
+    _ input: Operations.GetEventQuestionResponses.Input
+  ) async throws -> Operations.GetEventQuestionResponses.Output {
+    guard let userID = UserTokenContext.currentUserID else {
+      return .unauthorized
+    }
+    guard
+      let eventID = UUID(uuidString: input.path.eventId),
+      let questionID = UUID(uuidString: input.path.questionId)
+    else {
+      return .badRequest
+    }
+
+    do {
+      guard try await isEventOrganizer(eventID: eventID, userID: userID),
+        try await eventQuestionExists(questionID: questionID, eventID: eventID)
+      else {
+        return .notFound
+      }
+      let results = try await database.read {
+        db -> [(EventQuestionResponseRecord, EventQuestionResponseRevisionRecord, [UUID])] in
+        let responses =
+          try await EventQuestionResponseRecord
+          .where { $0.eventQuestionID.eq(questionID) }
+          .order { ($0.createdAt, $0.id) }
+          .fetchAll(db)
+        var out: [(EventQuestionResponseRecord, EventQuestionResponseRevisionRecord, [UUID])] = []
+        for response in responses {
+          guard let revision = try await latestResponseRevision(responseID: response.id, db: db)
+          else {
+            continue
+          }
+          let varietyIDs = try await responseVarietyIDs(revisionID: revision.id, db: db)
+          out.append((response, revision, varietyIDs))
+        }
+        return out
+      }
+      return .ok(
+        .init(
+          body: .json(
+            results.map {
+              Components.Schemas.EventQuestionResponse(
+                response: $0.0,
+                revision: $0.1,
+                wineVarietyIDs: $0.2
+              )
+            }
+          )
+        )
+      )
+    } catch {
+      logEventDatabaseError(
+        "event.response_list_failed",
+        "Failed to fetch event responses",
+        userID: userID,
+        error: error
+      )
+      return .badRequest
+    }
+  }
+
+  func getEventQuestionCorrectAnswer(
+    _ input: Operations.GetEventQuestionCorrectAnswer.Input
+  ) async throws -> Operations.GetEventQuestionCorrectAnswer.Output {
+    guard let userID = UserTokenContext.currentUserID else {
+      return .unauthorized
+    }
+    guard
+      let eventID = UUID(uuidString: input.path.eventId),
+      let questionID = UUID(uuidString: input.path.questionId)
+    else {
+      return .badRequest
+    }
+
+    do {
+      guard let event = try await latestEventSnapshot(eventID: eventID) else {
+        return .notFound
+      }
+      if event.event.organizerUserID != userID {
+        // Participants may only see the correct answer once it has been published.
+        guard try await canViewEvent(event, userID: userID),
+          let answersPublishedAt = event.revision.answersPublishedAt,
+          Date() >= answersPublishedAt
+        else {
+          return .notFound
+        }
+      }
+      guard try await eventQuestionExists(questionID: questionID, eventID: eventID) else {
+        return .notFound
+      }
+      let result = try await database.read {
+        db -> (
+          EventQuestionCorrectAnswerRecord, EventQuestionCorrectAnswerRevisionRecord, [UUID]
+        )? in
+        guard
+          let answer = try await correctAnswer(questionID: questionID, db: db),
+          let revision = try await latestCorrectAnswerRevision(answerID: answer.id, db: db)
+        else {
+          return nil
+        }
+        let varietyIDs = try await correctAnswerVarietyIDs(revisionID: revision.id, db: db)
+        return (answer, revision, varietyIDs)
+      }
+      guard let result else {
+        return .notFound
+      }
+      return .ok(
+        .init(
+          body: .json(
+            .init(answer: result.0, revision: result.1, wineVarietyIDs: result.2)
+          )
+        )
+      )
+    } catch {
+      logEventDatabaseError(
+        "event.correct_answer_read_failed",
+        "Failed to fetch correct answer",
         userID: userID,
         error: error
       )
@@ -1331,6 +1512,50 @@ extension API {
       }
       .limit(1)
       .fetchOne(db)
+  }
+
+  fileprivate func latestCorrectAnswerRevision(
+    answerID: UUID,
+    db: any Database.Connection.`Protocol`
+  ) async throws -> EventQuestionCorrectAnswerRevisionRecord? {
+    try await EventQuestionCorrectAnswerRevisionRecord
+      .where { $0.eventQuestionCorrectAnswerID.eq(answerID) }
+      .order { ($0.createdAt.desc(), $0.id.desc()) }
+      .limit(1)
+      .fetchOne(db)
+  }
+
+  fileprivate func correctAnswerVarietyIDs(
+    revisionID: UUID,
+    db: any Database.Connection.`Protocol`
+  ) async throws -> [UUID] {
+    let rows =
+      try await EventQuestionCorrectAnswerVarietyRecord
+      .where { $0.eventQuestionCorrectAnswerRevisionID.eq(revisionID) }
+      .fetchAll(db)
+    return rows.map(\.wineVarietyID).sorted { $0.uuidString < $1.uuidString }
+  }
+
+  fileprivate func latestResponseRevision(
+    responseID: UUID,
+    db: any Database.Connection.`Protocol`
+  ) async throws -> EventQuestionResponseRevisionRecord? {
+    try await EventQuestionResponseRevisionRecord
+      .where { $0.eventQuestionResponseID.eq(responseID) }
+      .order { ($0.submittedAt.desc(), $0.id.desc()) }
+      .limit(1)
+      .fetchOne(db)
+  }
+
+  fileprivate func responseVarietyIDs(
+    revisionID: UUID,
+    db: any Database.Connection.`Protocol`
+  ) async throws -> [UUID] {
+    let rows =
+      try await EventQuestionResponseVarietyRecord
+      .where { $0.eventQuestionResponseRevisionID.eq(revisionID) }
+      .fetchAll(db)
+    return rows.map(\.wineVarietyID).sorted { $0.uuidString < $1.uuidString }
   }
 
   fileprivate func insertCorrectAnswer(

--- a/public/documents/openapi.yml
+++ b/public/documents/openapi.yml
@@ -908,6 +908,54 @@ paths:
               schema:
                 $ref: '#/components/schemas/APIError'
   /events/{event_id}/questions/{question_id}/correct_answer:
+    get:
+      operationId: getEventQuestionCorrectAnswer
+      tags:
+        - Events
+      summary: Get correct answer
+      description: Returns the official correct answer for a blind tasting question. Organizers can always access it; participants only after answers are published.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: event_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: Target event ID in UUID format.
+        - name: question_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: Target event question ID in UUID format.
+      responses:
+        '200':
+          description: A success response with the correct answer.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EventQuestionCorrectAnswer'
+        '400':
+          description: A bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+        '404':
+          description: Not found Correct Answer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
     post:
       operationId: createEventQuestionCorrectAnswer
       tags:
@@ -1017,6 +1065,56 @@ paths:
               schema:
                 $ref: '#/components/schemas/APIError'
   /events/{event_id}/questions/{question_id}/responses:
+    get:
+      operationId: getEventQuestionResponses
+      tags:
+        - Events
+      summary: List question responses
+      description: Returns all submitted responses for a blind tasting question. Organizer only.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: event_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: Target event ID in UUID format.
+        - name: question_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: Target event question ID in UUID format.
+      responses:
+        '200':
+          description: A success response with the submitted responses.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/EventQuestionResponse'
+        '400':
+          description: A bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+        '404':
+          description: Not found Event Question
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
     post:
       operationId: createEventQuestionResponse
       tags:
@@ -1072,6 +1170,54 @@ paths:
               schema:
                 $ref: '#/components/schemas/APIError'
   /events/{event_id}/questions/{question_id}/responses/me:
+    get:
+      operationId: getMyEventQuestionResponse
+      tags:
+        - Events
+      summary: Get my question response
+      description: Returns the authenticated user's submitted response for a blind tasting question.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: event_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: Target event ID in UUID format.
+        - name: question_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: Target event question ID in UUID format.
+      responses:
+        '200':
+          description: A success response with the submitted response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EventQuestionResponse'
+        '400':
+          description: A bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+        '404':
+          description: Not found Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
     put:
       operationId: updateMyEventQuestionResponse
       tags:


### PR DESCRIPTION
## 概要
Closes #307

回答(response)・正解(correct answer)が書き込みのみだったため、取得用 GET を追加する。答え合わせ・採点・回答の再編集フローの前提。

## 追加エンドポイント
- `GET /events/{event_id}/questions/{question_id}/responses/me` — 本人の回答（`getMyEventQuestionResponse`）
- `GET /events/{event_id}/questions/{question_id}/responses` — 全回答・主催者のみ（`getEventQuestionResponses`）
- `GET /events/{event_id}/questions/{question_id}/correct_answer` — 正解（`getEventQuestionCorrectAnswer`）

いずれも最新リビジョン + variety を結合し、既存の Response builder を再利用。

## 認可・エラー
- responses/me: 本人のみ。未提出は **404**
- responses: 主催者のみ。それ以外は **404**
- correct_answer: 主催者は常時。参加者は `canViewEvent` かつ `answersPublishedAt` 経過後のみ。未公開・未設定・権限外は **404**
  - ※ issue の「公開前は 403 または 404」について、本リポジトリ規約に従い **404 に統一**

## 受け入れ条件
- [x] 不在時は一貫して 404
- [x] correct_answer の公開前アクセスは参加者に 404
- [x] openapi.yml に追記

🤖 Generated with [Claude Code](https://claude.com/claude-code)