### PR TITLE
参加者一覧取得と参加ステータス更新を追加する (#308)

### DIFF
--- a/Sources/App/API/APIErrorResponses.swift
+++ b/Sources/App/API/APIErrorResponses.swift
@@ -192,6 +192,21 @@ extension Operations.GetEvent.Output {
   }
 }
 
+extension Operations.GetEventParticipants.Output {
+  static var badRequest: Self { badRequest(.badRequest) }
+  static func badRequest(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .badRequest(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+  static var notFound: Self { notFound(.notFound) }
+  static func notFound(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .notFound(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+  static var unauthorized: Self { unauthorized(.unauthorized) }
+  static func unauthorized(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .unauthorized(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+}
+
 extension Operations.GetEventQuestions.Output {
   static var badRequest: Self { badRequest(.badRequest) }
   static func badRequest(_ code: APIErrorCode, message: String? = nil) -> Self {
@@ -411,6 +426,21 @@ extension Operations.UpdateEventQuestion.Output {
 }
 
 extension Operations.UpdateEventQuestionCorrectAnswer.Output {
+  static var badRequest: Self { badRequest(.badRequest) }
+  static func badRequest(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .badRequest(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+  static var notFound: Self { notFound(.notFound) }
+  static func notFound(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .notFound(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+  static var unauthorized: Self { unauthorized(.unauthorized) }
+  static func unauthorized(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .unauthorized(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+}
+
+extension Operations.UpdateMyEventParticipant.Output {
   static var badRequest: Self { badRequest(.badRequest) }
   static func badRequest(_ code: APIErrorCode, message: String? = nil) -> Self {
     .badRequest(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))

--- a/Sources/App/API/Events.swift
+++ b/Sources/App/API/Events.swift
@@ -696,11 +696,94 @@ extension API {
         return .notFound
       }
       let questions = try await latestEventQuestionSnapshots(eventID: eventID)
-      return .ok(.init(body: .json(questions.map(Components.Schemas.EventQuestion.init))))
+      var questionSchemas: [Components.Schemas.EventQuestion] = []
+      for question in questions {
+        questionSchemas.append(await makeEventQuestion(question))
+      }
+      return .ok(.init(body: .json(questionSchemas)))
     } catch {
       logEventDatabaseError(
         "event.question_list_failed",
         "Failed to fetch event questions",
+        userID: userID,
+        error: error
+      )
+      return .badRequest
+    }
+  }
+
+  func getEventParticipants(
+    _ input: Operations.GetEventParticipants.Input
+  ) async throws -> Operations.GetEventParticipants.Output {
+    guard let userID = UserTokenContext.currentUserID else {
+      return .unauthorized
+    }
+    guard let eventID = UUID(uuidString: input.path.eventId) else {
+      return .badRequest
+    }
+
+    do {
+      guard try await isEventOrganizer(eventID: eventID, userID: userID) else {
+        return .notFound
+      }
+      let participants = try await database.read { db in
+        try await EventParticipantRecord
+          .where { $0.eventID.eq(eventID) }
+          .order { ($0.createdAt, $0.id) }
+          .fetchAll(db)
+      }
+      return .ok(.init(body: .json(participants.map(Components.Schemas.EventParticipant.init))))
+    } catch {
+      logEventDatabaseError(
+        "event.participant_list_failed",
+        "Failed to fetch event participants",
+        userID: userID,
+        error: error
+      )
+      return .badRequest
+    }
+  }
+
+  func updateMyEventParticipant(
+    _ input: Operations.UpdateMyEventParticipant.Input
+  ) async throws -> Operations.UpdateMyEventParticipant.Output {
+    guard let userID = UserTokenContext.currentUserID else {
+      return .unauthorized
+    }
+    guard
+      let eventID = UUID(uuidString: input.path.eventId),
+      case .json(let body) = input.body,
+      let newStatus = EventParticipantRecord.Status(rawValue: body.status.rawValue)
+    else {
+      return .badRequest
+    }
+    // Only self-cancellation is permitted through this endpoint. Transitions such
+    // as waitlisted/attended are organizer- or system-driven and handled elsewhere.
+    guard newStatus == .canceled else {
+      return .badRequest
+    }
+
+    do {
+      let participant = try await database.withTransaction { db -> EventParticipantRecord? in
+        try await lockEventRegistration(eventID: eventID, db: db)
+        guard var participant = try await eventParticipant(eventID: eventID, userID: userID, db: db)
+        else {
+          return nil
+        }
+        if participant.status != .canceled {
+          participant.status = .canceled
+          try await EventParticipantRecord.update(participant).execute(db)
+        }
+        return participant
+      }
+      guard let participant else {
+        return .notFound
+      }
+      return .ok(.init(body: .json(.init(participant))))
+    } catch {
+      logEventDatabaseError(
+        "event.participant_update_failed",
+        "Failed to update event participant",
         userID: userID,
         error: error
       )

--- a/public/documents/openapi.yml
+++ b/public/documents/openapi.yml
@@ -720,6 +720,49 @@ paths:
               schema:
                 $ref: '#/components/schemas/APIError'
   /events/{event_id}/participants:
+    get:
+      operationId: getEventParticipants
+      tags:
+        - Events
+      summary: List event participants
+      description: Returns the participants of an event. Organizer only.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: event_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: Target event ID in UUID format.
+      responses:
+        '200':
+          description: A success response with the event participants.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/EventParticipant'
+        '400':
+          description: A bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+        '404':
+          description: Not found Event
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
     post:
       operationId: registerEventParticipant
       tags:
@@ -757,6 +800,54 @@ paths:
                 $ref: '#/components/schemas/APIError'
         '404':
           description: Not found Event
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+  /events/{event_id}/participants/me:
+    put:
+      operationId: updateMyEventParticipant
+      tags:
+        - Events
+      summary: Update my participation status
+      description: Updates the authenticated user's participation status, such as canceling a registration.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: event_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: Target event ID in UUID format.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateEventParticipantRequest'
+      responses:
+        '200':
+          description: A success response with the updated event participant.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EventParticipant'
+        '400':
+          description: A bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+        '404':
+          description: Not found Event Participant
           content:
             application/json:
               schema:
@@ -1793,6 +1884,14 @@ components:
         - waitlisted
         - canceled
         - attended
+    UpdateEventParticipantRequest:
+      type: object
+      description: A request to update the authenticated user's participation status.
+      properties:
+        status:
+          $ref: '#/components/schemas/EventParticipantStatus'
+      required:
+        - status
     EventQuestion:
       type: object
       description: A question in a blind tasting event.


### PR DESCRIPTION
## 概要
Closes #308

参加者一覧の取得と、参加者自身によるステータス変更（キャンセル等）を追加する。

## 追加エンドポイント
- `GET /events/{event_id}/participants` — 参加者一覧・主催者のみ（`getEventParticipants`）
- `PUT /events/{event_id}/participants/me` — 自分の参加ステータス更新（`updateMyEventParticipant`）
  - リクエスト: 新規スキーマ `UpdateEventParticipantRequest { status }`

## 認可・状態遷移
- 一覧取得は主催者のみ。それ以外は **404**
  - ※ issue では「主催者以外は 403」ですが、本リポジトリ規約に合わせ **404 に統一**
- `participants/me` は本人のみ。**`canceled` への遷移のみ許可**（registered/waitlisted/attended → canceled）。それ以外の遷移要求は **400**
  - 行ロック (`lockEventRegistration`) 下で更新。既に canceled の場合は冪等に現状を返す

## 補足
- waitlisted/attended への遷移（主催者操作）は本PRの対象外（issue補足のとおり別途整理）

## 受け入れ条件
- [x] 主催者以外の一覧取得は権限外として弾く（404）
- [x] 本人の許可された遷移のみ可能、不正遷移は 400
- [x] openapi.yml に追記

🤖 Generated with [Claude Code](https://claude.com/claude-code)