### PR TITLE
getEventQuestions のビルド破損を修正する

### DIFF
--- a/Sources/App/API/Events.swift
+++ b/Sources/App/API/Events.swift
@@ -696,7 +696,11 @@ extension API {
         return .notFound
       }
       let questions = try await latestEventQuestionSnapshots(eventID: eventID)
-      return .ok(.init(body: .json(questions.map(Components.Schemas.EventQuestion.init))))
+      var questionSchemas: [Components.Schemas.EventQuestion] = []
+      for question in questions {
+        questionSchemas.append(await makeEventQuestion(question))
+      }
+      return .ok(.init(body: .json(questionSchemas)))
     } catch {
       logEventDatabaseError(
         "event.question_list_failed",


### PR DESCRIPTION
## 概要
`main` のビルドが壊れているため修正する。

#306 (#311) で追加した `getEventQuestions` は同期版の `Components.Schemas.EventQuestion.init(_:)` を参照していたが、その後にマージされた #310 (#314) が同 init を `init(_:imageURL:)` に変更したため、`questions.map(Components.Schemas.EventQuestion.init)` がコンパイルできなくなっていた（`Events.swift:699` "No exact matches in call to instance method 'map'"）。

## 変更点
- `getEventQuestions` を `makeEventQuestion`（imageURL 解決つき・非同期）経由に変更

ビルド成功を確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)