### PR TITLE
問題単位の採点とシーズン制レーティングを追加する

### DIFF
--- a/Database/migrations/20260712120000_scoring_and_rating.sql
+++ b/Database/migrations/20260712120000_scoring_and_rating.sql
@@ -1,0 +1,149 @@
+-- Event timeline: response deadline + required answer publish time
+ALTER TABLE public.event_revisions
+  ADD COLUMN responses_due_at timestamptz;
+
+UPDATE public.event_revisions
+SET
+  responses_due_at = ends_at
+WHERE responses_due_at IS NULL;
+
+UPDATE public.event_revisions
+SET
+  answers_published_at = GREATEST(ends_at, responses_due_at)
+WHERE answers_published_at IS NULL;
+
+ALTER TABLE public.event_revisions
+  ALTER COLUMN responses_due_at SET NOT NULL,
+  ALTER COLUMN answers_published_at SET NOT NULL;
+
+ALTER TABLE public.event_revisions
+  ADD CONSTRAINT event_revisions_starts_before_or_at_responses_due
+    CHECK (starts_at <= responses_due_at),
+  ADD CONSTRAINT event_revisions_responses_due_before_or_at_answers_published
+    CHECK (responses_due_at <= answers_published_at);
+
+-- Move scoring rules from event to question
+DROP TABLE IF EXISTS public.event_region_score_rules;
+
+CREATE TABLE public.event_question_region_score_rules (
+  event_question_id uuid NOT NULL,
+  wine_region_type_id uuid NOT NULL,
+  points integer NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT event_question_region_score_rules_pk PRIMARY KEY (event_question_id, wine_region_type_id),
+  CONSTRAINT event_question_region_score_rules_question_fk
+    FOREIGN KEY (event_question_id) REFERENCES public.event_questions (id) ON DELETE RESTRICT,
+  CONSTRAINT event_question_region_score_rules_wine_region_type_fk
+    FOREIGN KEY (wine_region_type_id) REFERENCES public.wine_region_types (id) ON DELETE RESTRICT,
+  CONSTRAINT event_question_region_score_rules_points_non_negative CHECK (points >= 0)
+);
+
+CREATE INDEX event_question_region_score_rules_wine_region_type_id_idx
+  ON public.event_question_region_score_rules(wine_region_type_id);
+
+CREATE TABLE public.event_question_score_component_rules (
+  event_question_id uuid NOT NULL,
+  component text NOT NULL,
+  points integer NOT NULL,
+  partial_points integer,
+  alcohol_tolerance double precision,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT event_question_score_component_rules_pk PRIMARY KEY (event_question_id, component),
+  CONSTRAINT event_question_score_component_rules_question_fk
+    FOREIGN KEY (event_question_id) REFERENCES public.event_questions (id) ON DELETE RESTRICT,
+  CONSTRAINT event_question_score_component_rules_component_valid
+    CHECK (component IN ('variety', 'vintage', 'alcohol', 'producer', 'feature')),
+  CONSTRAINT event_question_score_component_rules_points_non_negative CHECK (points >= 0),
+  CONSTRAINT event_question_score_component_rules_partial_points_non_negative
+    CHECK (partial_points IS NULL OR partial_points >= 0),
+  CONSTRAINT event_question_score_component_rules_partial_lte_points
+    CHECK (partial_points IS NULL OR partial_points <= points),
+  CONSTRAINT event_question_score_component_rules_alcohol_tolerance_non_negative
+    CHECK (alcohol_tolerance IS NULL OR alcohol_tolerance >= 0),
+  CONSTRAINT event_question_score_component_rules_alcohol_tolerance_only_for_alcohol
+    CHECK (alcohol_tolerance IS NULL OR component = 'alcohol')
+);
+
+-- Producer / feature fields on answers
+ALTER TABLE public.event_question_correct_answer_revisions
+  ADD COLUMN producer_wine_region_id uuid,
+  ADD COLUMN feature text,
+  ADD CONSTRAINT event_question_correct_answer_revisions_producer_wine_region_fk
+    FOREIGN KEY (producer_wine_region_id) REFERENCES public.wine_regions (id) ON DELETE RESTRICT;
+
+CREATE INDEX event_question_correct_answer_revisions_producer_wine_region_id_idx
+  ON public.event_question_correct_answer_revisions(producer_wine_region_id);
+
+ALTER TABLE public.event_question_response_revisions
+  ADD COLUMN producer_wine_region_id uuid,
+  ADD COLUMN feature text,
+  ADD CONSTRAINT event_question_response_revisions_producer_wine_region_fk
+    FOREIGN KEY (producer_wine_region_id) REFERENCES public.wine_regions (id) ON DELETE RESTRICT;
+
+CREATE INDEX event_question_response_revisions_producer_wine_region_id_idx
+  ON public.event_question_response_revisions(producer_wine_region_id);
+
+-- Rating seasons
+CREATE TABLE public.rating_seasons (
+  id uuid NOT NULL,
+  name text NOT NULL,
+  starts_at timestamptz NOT NULL,
+  ends_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT rating_seasons_pk PRIMARY KEY (id),
+  CONSTRAINT rating_seasons_name_not_blank CHECK (char_length(trim(name)) > 0),
+  CONSTRAINT rating_seasons_starts_before_ends CHECK (ends_at IS NULL OR starts_at < ends_at)
+);
+
+CREATE UNIQUE INDEX rating_seasons_one_active_idx
+  ON public.rating_seasons ((true))
+  WHERE ends_at IS NULL;
+
+CREATE TABLE public.user_season_ratings (
+  user_id uuid NOT NULL,
+  season_id uuid NOT NULL,
+  rating integer NOT NULL DEFAULT 1000,
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT user_season_ratings_pk PRIMARY KEY (user_id, season_id),
+  CONSTRAINT user_season_ratings_user_fk
+    FOREIGN KEY (user_id) REFERENCES public.users (id) ON DELETE RESTRICT,
+  CONSTRAINT user_season_ratings_season_fk
+    FOREIGN KEY (season_id) REFERENCES public.rating_seasons (id) ON DELETE RESTRICT
+);
+
+CREATE INDEX user_season_ratings_season_rating_idx
+  ON public.user_season_ratings(season_id, rating DESC, user_id);
+
+CREATE TABLE public.user_rating_ledger (
+  id uuid NOT NULL,
+  user_id uuid NOT NULL,
+  season_id uuid NOT NULL,
+  event_question_id uuid NOT NULL,
+  performance double precision NOT NULL,
+  field_average double precision NOT NULL,
+  delta integer NOT NULL,
+  rating_after integer NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT user_rating_ledger_pk PRIMARY KEY (id),
+  CONSTRAINT user_rating_ledger_user_fk
+    FOREIGN KEY (user_id) REFERENCES public.users (id) ON DELETE RESTRICT,
+  CONSTRAINT user_rating_ledger_season_fk
+    FOREIGN KEY (season_id) REFERENCES public.rating_seasons (id) ON DELETE RESTRICT,
+  CONSTRAINT user_rating_ledger_question_fk
+    FOREIGN KEY (event_question_id) REFERENCES public.event_questions (id) ON DELETE RESTRICT,
+  CONSTRAINT user_rating_ledger_season_question_user_key UNIQUE (season_id, event_question_id, user_id),
+  CONSTRAINT user_rating_ledger_performance_range CHECK (performance >= 0 AND performance <= 1),
+  CONSTRAINT user_rating_ledger_field_average_range CHECK (field_average >= 0 AND field_average <= 1)
+);
+
+CREATE INDEX user_rating_ledger_user_season_created_idx
+  ON public.user_rating_ledger(user_id, season_id, created_at DESC);
+
+INSERT INTO public.rating_seasons (id, name, starts_at, ends_at, created_at)
+VALUES (
+  '01900000-0000-7000-8000-000000000001',
+  'Season 1',
+  TIMESTAMPTZ '2026-01-01 00:00:00+00',
+  NULL,
+  now()
+);

--- a/Database/migrations/20260712120000_scoring_and_rating.sql
+++ b/Database/migrations/20260712120000_scoring_and_rating.sql
@@ -22,8 +22,9 @@ ALTER TABLE public.event_revisions
   ADD CONSTRAINT event_revisions_responses_due_before_or_at_answers_published
     CHECK (responses_due_at <= answers_published_at);
 
--- Move scoring rules from event to question
-DROP TABLE IF EXISTS public.event_region_score_rules;
+-- Event-level score rules are replaced by per-question tables.
+-- Existing rows are discarded intentionally (no data migration).
+DROP TABLE IF EXISTS public.event_region_score_rules CASCADE;
 
 CREATE TABLE public.event_question_region_score_rules (
   event_question_id uuid NOT NULL,

--- a/Database/migrations/atlas.sum
+++ b/Database/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:IoivRpcxvFHmFXwgfytPEcAhmnBnx639d1yI2xsKOyI=
+h1:kkVmRAHe53YEJ5ua7AcY2LePiDD3JlTF4he7qmg5vGY=
 000001_initial_schema.sql h1:iQH63d3ckYBCOcFnKf6nkOsitlGdpumeDPFZMcnCuz4=
 20260531034124_events.sql h1:PedeyzF85utC/LHxKCc9z5Gs8puDptsTNkRapWNKjrI=
 20260531060000_seed_wine_master_data.sql h1:54BEUlfrgkN/2W4aM32RYFg5x74O9IeSS/lR0v04t7g=
@@ -7,3 +7,4 @@ h1:IoivRpcxvFHmFXwgfytPEcAhmnBnx639d1yI2xsKOyI=
 20260614000000_event_numeric_to_double.sql h1:HYqgZIhm49OAktZVbjez1REs+kI/kqPcAoZX6BViHeE=
 20260614010000_correct_answer_aggregate.sql h1:ocjHzVrl5ods0XrvXy9gNvLXPoR7O3nCoN/wzn/4mRA=
 20260614020000_response_aggregate.sql h1:7VhFaEnN4OqUqhR/6YICgw42hTToFVPc1Yc1Y/Rq3ug=
+20260712120000_scoring_and_rating.sql h1:jaOAahjZx+Osw7PBLFnhoXHNJ4AHZINTP6ufPheBAYE=

--- a/Database/migrations/atlas.sum
+++ b/Database/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:kkVmRAHe53YEJ5ua7AcY2LePiDD3JlTF4he7qmg5vGY=
+h1:H2w0TP/uMjKXHOp5ujjLFDwzaEpOCEyfkJ3PGSGDN0c=
 000001_initial_schema.sql h1:iQH63d3ckYBCOcFnKf6nkOsitlGdpumeDPFZMcnCuz4=
 20260531034124_events.sql h1:PedeyzF85utC/LHxKCc9z5Gs8puDptsTNkRapWNKjrI=
 20260531060000_seed_wine_master_data.sql h1:54BEUlfrgkN/2W4aM32RYFg5x74O9IeSS/lR0v04t7g=
@@ -7,4 +7,4 @@ h1:kkVmRAHe53YEJ5ua7AcY2LePiDD3JlTF4he7qmg5vGY=
 20260614000000_event_numeric_to_double.sql h1:HYqgZIhm49OAktZVbjez1REs+kI/kqPcAoZX6BViHeE=
 20260614010000_correct_answer_aggregate.sql h1:ocjHzVrl5ods0XrvXy9gNvLXPoR7O3nCoN/wzn/4mRA=
 20260614020000_response_aggregate.sql h1:7VhFaEnN4OqUqhR/6YICgw42hTToFVPc1Yc1Y/Rq3ug=
-20260712120000_scoring_and_rating.sql h1:jaOAahjZx+Osw7PBLFnhoXHNJ4AHZINTP6ufPheBAYE=
+20260712120000_scoring_and_rating.sql h1:g2/fQ1+g49xP3rW1SSmW09zlL0KcopVgRJVex4wOn2E=

--- a/Database/schema.sql
+++ b/Database/schema.sql
@@ -98,7 +98,8 @@ CREATE TABLE public.event_revisions (
   starts_at timestamptz NOT NULL,
   ends_at timestamptz NOT NULL,
   event_period tstzrange GENERATED ALWAYS AS (tstzrange(starts_at, ends_at, '[)')) STORED,
-  answers_published_at timestamptz,
+  responses_due_at timestamptz NOT NULL,
+  answers_published_at timestamptz NOT NULL,
   capacity integer,
   entry_fee_minor_amount bigint,
   entry_fee_currency_code text,
@@ -116,6 +117,8 @@ CREATE TABLE public.event_revisions (
   CONSTRAINT event_revisions_venue_latitude_range CHECK (venue_latitude IS NULL OR (venue_latitude >= -90 AND venue_latitude <= 90)),
   CONSTRAINT event_revisions_venue_longitude_range CHECK (venue_longitude IS NULL OR (venue_longitude >= -180 AND venue_longitude <= 180)),
   CONSTRAINT event_revisions_starts_before_ends CHECK (starts_at < ends_at),
+  CONSTRAINT event_revisions_starts_before_or_at_responses_due CHECK (starts_at <= responses_due_at),
+  CONSTRAINT event_revisions_responses_due_before_or_at_answers_published CHECK (responses_due_at <= answers_published_at),
   CONSTRAINT event_revisions_registration_starts_before_ends CHECK (registration_starts_at IS NULL OR registration_ends_at IS NULL OR registration_starts_at < registration_ends_at),
   CONSTRAINT event_revisions_capacity_positive CHECK (capacity IS NULL OR capacity > 0),
   CONSTRAINT event_revisions_entry_fee_minor_amount_non_negative CHECK (entry_fee_minor_amount IS NULL OR entry_fee_minor_amount >= 0),
@@ -247,18 +250,22 @@ CREATE TABLE public.event_question_correct_answer_revisions (
   id uuid NOT NULL,
   event_question_correct_answer_id uuid NOT NULL,
   wine_region_id uuid,
+  producer_wine_region_id uuid,
+  feature text,
   vintage integer,
   alcohol_by_volume double precision,
   created_at timestamptz NOT NULL DEFAULT now(),
   CONSTRAINT event_question_correct_answer_revisions_pk PRIMARY KEY (id),
   CONSTRAINT event_question_correct_answer_revisions_answer_fk FOREIGN KEY (event_question_correct_answer_id) REFERENCES public.event_question_correct_answers (id) ON DELETE RESTRICT,
   CONSTRAINT event_question_correct_answer_revisions_wine_region_fk FOREIGN KEY (wine_region_id) REFERENCES public.wine_regions (id) ON DELETE RESTRICT,
+  CONSTRAINT event_question_correct_answer_revisions_producer_wine_region_fk FOREIGN KEY (producer_wine_region_id) REFERENCES public.wine_regions (id) ON DELETE RESTRICT,
   CONSTRAINT event_question_correct_answer_revisions_vintage_positive CHECK (vintage IS NULL OR vintage > 0),
   CONSTRAINT event_question_correct_answer_revisions_alcohol_by_volume_range CHECK (alcohol_by_volume IS NULL OR (alcohol_by_volume >= 0 AND alcohol_by_volume <= 100))
 );
 
 CREATE INDEX event_question_correct_answer_revisions_answer_latest_idx ON public.event_question_correct_answer_revisions(event_question_correct_answer_id, created_at DESC, id DESC);
 CREATE INDEX event_question_correct_answer_revisions_wine_region_id_idx ON public.event_question_correct_answer_revisions(wine_region_id);
+CREATE INDEX event_question_correct_answer_revisions_producer_wine_region_id_idx ON public.event_question_correct_answer_revisions(producer_wine_region_id);
 
 CREATE TABLE public.event_question_correct_answer_revision_varieties (
   event_question_correct_answer_revision_id uuid NOT NULL,
@@ -288,6 +295,8 @@ CREATE TABLE public.event_question_response_revisions (
   id uuid NOT NULL,
   event_question_response_id uuid NOT NULL,
   wine_region_id uuid,
+  producer_wine_region_id uuid,
+  feature text,
   vintage integer,
   alcohol_by_volume double precision,
   note text,
@@ -295,12 +304,14 @@ CREATE TABLE public.event_question_response_revisions (
   CONSTRAINT event_question_response_revisions_pk PRIMARY KEY (id),
   CONSTRAINT event_question_response_revisions_response_fk FOREIGN KEY (event_question_response_id) REFERENCES public.event_question_responses (id) ON DELETE RESTRICT,
   CONSTRAINT event_question_response_revisions_wine_region_fk FOREIGN KEY (wine_region_id) REFERENCES public.wine_regions (id) ON DELETE RESTRICT,
+  CONSTRAINT event_question_response_revisions_producer_wine_region_fk FOREIGN KEY (producer_wine_region_id) REFERENCES public.wine_regions (id) ON DELETE RESTRICT,
   CONSTRAINT event_question_response_revisions_vintage_positive CHECK (vintage IS NULL OR vintage > 0),
   CONSTRAINT event_question_response_revisions_alcohol_by_volume_range CHECK (alcohol_by_volume IS NULL OR (alcohol_by_volume >= 0 AND alcohol_by_volume <= 100))
 );
 
 CREATE INDEX event_question_response_revisions_response_latest_idx ON public.event_question_response_revisions(event_question_response_id, submitted_at DESC, id DESC);
 CREATE INDEX event_question_response_revisions_wine_region_id_idx ON public.event_question_response_revisions(wine_region_id);
+CREATE INDEX event_question_response_revisions_producer_wine_region_id_idx ON public.event_question_response_revisions(producer_wine_region_id);
 
 CREATE TABLE public.event_question_response_revision_varieties (
   event_question_response_revision_id uuid NOT NULL,
@@ -313,15 +324,78 @@ CREATE TABLE public.event_question_response_revision_varieties (
 
 CREATE INDEX event_question_response_revision_varieties_wine_variety_id_idx ON public.event_question_response_revision_varieties(wine_variety_id);
 
-CREATE TABLE public.event_region_score_rules (
-  event_id uuid NOT NULL,
+CREATE TABLE public.event_question_region_score_rules (
+  event_question_id uuid NOT NULL,
   wine_region_type_id uuid NOT NULL,
   points integer NOT NULL,
   created_at timestamptz NOT NULL DEFAULT now(),
-  CONSTRAINT event_region_score_rules_pk PRIMARY KEY (event_id, wine_region_type_id),
-  CONSTRAINT event_region_score_rules_event_fk FOREIGN KEY (event_id) REFERENCES public.events (id) ON DELETE RESTRICT,
-  CONSTRAINT event_region_score_rules_wine_region_type_fk FOREIGN KEY (wine_region_type_id) REFERENCES public.wine_region_types (id) ON DELETE RESTRICT,
-  CONSTRAINT event_region_score_rules_points_non_negative CHECK (points >= 0)
+  CONSTRAINT event_question_region_score_rules_pk PRIMARY KEY (event_question_id, wine_region_type_id),
+  CONSTRAINT event_question_region_score_rules_question_fk FOREIGN KEY (event_question_id) REFERENCES public.event_questions (id) ON DELETE RESTRICT,
+  CONSTRAINT event_question_region_score_rules_wine_region_type_fk FOREIGN KEY (wine_region_type_id) REFERENCES public.wine_region_types (id) ON DELETE RESTRICT,
+  CONSTRAINT event_question_region_score_rules_points_non_negative CHECK (points >= 0)
 );
 
-CREATE INDEX event_region_score_rules_wine_region_type_id_idx ON public.event_region_score_rules(wine_region_type_id);
+CREATE INDEX event_question_region_score_rules_wine_region_type_id_idx ON public.event_question_region_score_rules(wine_region_type_id);
+
+CREATE TABLE public.event_question_score_component_rules (
+  event_question_id uuid NOT NULL,
+  component text NOT NULL,
+  points integer NOT NULL,
+  partial_points integer,
+  alcohol_tolerance double precision,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT event_question_score_component_rules_pk PRIMARY KEY (event_question_id, component),
+  CONSTRAINT event_question_score_component_rules_question_fk FOREIGN KEY (event_question_id) REFERENCES public.event_questions (id) ON DELETE RESTRICT,
+  CONSTRAINT event_question_score_component_rules_component_valid CHECK (component IN ('variety', 'vintage', 'alcohol', 'producer', 'feature')),
+  CONSTRAINT event_question_score_component_rules_points_non_negative CHECK (points >= 0),
+  CONSTRAINT event_question_score_component_rules_partial_points_non_negative CHECK (partial_points IS NULL OR partial_points >= 0),
+  CONSTRAINT event_question_score_component_rules_partial_lte_points CHECK (partial_points IS NULL OR partial_points <= points),
+  CONSTRAINT event_question_score_component_rules_alcohol_tolerance_non_negative CHECK (alcohol_tolerance IS NULL OR alcohol_tolerance >= 0),
+  CONSTRAINT event_question_score_component_rules_alcohol_tolerance_only_for_alcohol CHECK (alcohol_tolerance IS NULL OR component = 'alcohol')
+);
+
+CREATE TABLE public.rating_seasons (
+  id uuid NOT NULL,
+  name text NOT NULL,
+  starts_at timestamptz NOT NULL,
+  ends_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT rating_seasons_pk PRIMARY KEY (id),
+  CONSTRAINT rating_seasons_name_not_blank CHECK (char_length(trim(name)) > 0),
+  CONSTRAINT rating_seasons_starts_before_ends CHECK (ends_at IS NULL OR starts_at < ends_at)
+);
+
+CREATE UNIQUE INDEX rating_seasons_one_active_idx ON public.rating_seasons ((true)) WHERE ends_at IS NULL;
+
+CREATE TABLE public.user_season_ratings (
+  user_id uuid NOT NULL,
+  season_id uuid NOT NULL,
+  rating integer NOT NULL DEFAULT 1000,
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT user_season_ratings_pk PRIMARY KEY (user_id, season_id),
+  CONSTRAINT user_season_ratings_user_fk FOREIGN KEY (user_id) REFERENCES public.users (id) ON DELETE RESTRICT,
+  CONSTRAINT user_season_ratings_season_fk FOREIGN KEY (season_id) REFERENCES public.rating_seasons (id) ON DELETE RESTRICT
+);
+
+CREATE INDEX user_season_ratings_season_rating_idx ON public.user_season_ratings(season_id, rating DESC, user_id);
+
+CREATE TABLE public.user_rating_ledger (
+  id uuid NOT NULL,
+  user_id uuid NOT NULL,
+  season_id uuid NOT NULL,
+  event_question_id uuid NOT NULL,
+  performance double precision NOT NULL,
+  field_average double precision NOT NULL,
+  delta integer NOT NULL,
+  rating_after integer NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT user_rating_ledger_pk PRIMARY KEY (id),
+  CONSTRAINT user_rating_ledger_user_fk FOREIGN KEY (user_id) REFERENCES public.users (id) ON DELETE RESTRICT,
+  CONSTRAINT user_rating_ledger_season_fk FOREIGN KEY (season_id) REFERENCES public.rating_seasons (id) ON DELETE RESTRICT,
+  CONSTRAINT user_rating_ledger_question_fk FOREIGN KEY (event_question_id) REFERENCES public.event_questions (id) ON DELETE RESTRICT,
+  CONSTRAINT user_rating_ledger_season_question_user_key UNIQUE (season_id, event_question_id, user_id),
+  CONSTRAINT user_rating_ledger_performance_range CHECK (performance >= 0 AND performance <= 1),
+  CONSTRAINT user_rating_ledger_field_average_range CHECK (field_average >= 0 AND field_average <= 1)
+);
+
+CREATE INDEX user_rating_ledger_user_season_created_idx ON public.user_rating_ledger(user_id, season_id, created_at DESC);

--- a/Database/seeds/006_rating_seasons.sql
+++ b/Database/seeds/006_rating_seasons.sql
@@ -1,0 +1,9 @@
+INSERT INTO public.rating_seasons (id, name, starts_at, ends_at, created_at)
+VALUES (
+  '01900000-0000-7000-8000-000000000001',
+  'Season 1',
+  TIMESTAMPTZ '2026-01-01 00:00:00+00',
+  NULL,
+  now()
+)
+ON CONFLICT (id) DO NOTHING;

--- a/Package.resolved
+++ b/Package.resolved
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/multipart-kit.git",
       "state" : {
-        "revision" : "481a44661dae96a609fc30f6ddad8d6f35c51947",
-        "version" : "5.0.0-alpha.5"
+        "revision" : "fb04cffa1d56dcd90a9a30bb300c2608e4b38000",
+        "version" : "5.0.0-beta.1"
       }
     },
     {
@@ -168,8 +168,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-async-algorithms.git",
       "state" : {
-        "revision" : "d0b4a06d0f173a2f3be27d3ea21b3c3aa18db440",
-        "version" : "1.1.4"
+        "revision" : "3da39bbc4e687d4192af7c9cf4eab805745a0b9c",
+        "version" : "1.1.5"
       }
     },
     {
@@ -366,8 +366,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-ssl.git",
       "state" : {
-        "revision" : "407d82d5b6cc00e1c3fb83a81b1539b70c788c5e",
-        "version" : "2.37.1"
+        "revision" : "d930168b86f46ca51a4bc09c5ca45c1833db8067",
+        "version" : "2.37.2"
       }
     },
     {
@@ -492,8 +492,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-system.git",
       "state" : {
-        "revision" : "b5544ba79a70a0cb3563e75bf26dc198d6b40ed3",
-        "version" : "1.7.4"
+        "revision" : "50688cacbd41d547e9eb9f7a213542340b7c442b",
+        "version" : "1.7.5"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "349f90bdd5ad162015e528079519aa85a7e56ec93297a9d7e28d0ac2893f9606",
+  "originHash" : "841c6909a0d907fd6c450517a69e987bfc14b19c1afe12b38ac150e907147664",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -98,15 +98,6 @@
       "state" : {
         "revision" : "57b6318128e3f901c93f4fbf98d1c1464ec168d3",
         "version" : "6.2.0"
-      }
-    },
-    {
-      "identity" : "opencombine",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/OpenCombine/OpenCombine.git",
-      "state" : {
-        "revision" : "8576f0d579b27020beccbccc3ea6844f3ddfc2c2",
-        "version" : "0.14.0"
       }
     },
     {

--- a/Sources/App/API/APIErrorResponses.swift
+++ b/Sources/App/API/APIErrorResponses.swift
@@ -582,6 +582,10 @@ extension Operations.GetMyRating.Output {
   static func unauthorized(_ code: APIErrorCode, message: String? = nil) -> Self {
     .unauthorized(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
   }
+  static var notFound: Self { notFound(.notFound) }
+  static func notFound(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .notFound(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
 }
 
 extension Operations.GetRatingLeaderboard.Output {
@@ -607,5 +611,9 @@ extension Operations.CreateRatingSeason.Output {
   static var unauthorized: Self { unauthorized(.unauthorized) }
   static func unauthorized(_ code: APIErrorCode, message: String? = nil) -> Self {
     .unauthorized(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+  static var forbidden: Self { forbidden(.forbidden) }
+  static func forbidden(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .forbidden(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
   }
 }

--- a/Sources/App/API/APIErrorResponses.swift
+++ b/Sources/App/API/APIErrorResponses.swift
@@ -4,6 +4,7 @@ enum APIErrorCode: String, Sendable {
   case badRequest = "bad_request"
   case unauthorized
   case notFound = "not_found"
+  case forbidden
 
   case invalidRequest = "invalid_request"
   case challengeVerifyFailed = "challenge_verify_failed"
@@ -508,6 +509,100 @@ extension Operations.UpdateMyEventQuestionResponse.Output {
   static var notFound: Self { notFound(.notFound) }
   static func notFound(_ code: APIErrorCode, message: String? = nil) -> Self {
     .notFound(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+  static var unauthorized: Self { unauthorized(.unauthorized) }
+  static func unauthorized(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .unauthorized(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+}
+
+extension Operations.GetEventScores.Output {
+  static var badRequest: Self { badRequest(.badRequest) }
+  static func badRequest(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .badRequest(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+  static var unauthorized: Self { unauthorized(.unauthorized) }
+  static func unauthorized(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .unauthorized(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+  static var notFound: Self { notFound(.notFound) }
+  static func notFound(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .notFound(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+  static var forbidden: Self { forbidden(.forbidden) }
+  static func forbidden(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .forbidden(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+}
+
+extension Operations.GetEventLeaderboard.Output {
+  static var badRequest: Self { badRequest(.badRequest) }
+  static func badRequest(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .badRequest(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+  static var unauthorized: Self { unauthorized(.unauthorized) }
+  static func unauthorized(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .unauthorized(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+  static var notFound: Self { notFound(.notFound) }
+  static func notFound(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .notFound(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+  static var forbidden: Self { forbidden(.forbidden) }
+  static func forbidden(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .forbidden(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+}
+
+extension Operations.GetEventQuestionScores.Output {
+  static var badRequest: Self { badRequest(.badRequest) }
+  static func badRequest(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .badRequest(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+  static var unauthorized: Self { unauthorized(.unauthorized) }
+  static func unauthorized(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .unauthorized(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+  static var notFound: Self { notFound(.notFound) }
+  static func notFound(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .notFound(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+  static var forbidden: Self { forbidden(.forbidden) }
+  static func forbidden(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .forbidden(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+}
+
+extension Operations.GetMyRating.Output {
+  static var badRequest: Self { badRequest(.badRequest) }
+  static func badRequest(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .badRequest(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+  static var unauthorized: Self { unauthorized(.unauthorized) }
+  static func unauthorized(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .unauthorized(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+}
+
+extension Operations.GetRatingLeaderboard.Output {
+  static var badRequest: Self { badRequest(.badRequest) }
+  static func badRequest(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .badRequest(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+  static var unauthorized: Self { unauthorized(.unauthorized) }
+  static func unauthorized(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .unauthorized(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+  static var notFound: Self { notFound(.notFound) }
+  static func notFound(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .notFound(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
+  }
+}
+
+extension Operations.CreateRatingSeason.Output {
+  static var badRequest: Self { badRequest(.badRequest) }
+  static func badRequest(_ code: APIErrorCode, message: String? = nil) -> Self {
+    .badRequest(.init(body: .json(APIErrorResponseFactory.make(code, message: message))))
   }
   static var unauthorized: Self { unauthorized(.unauthorized) }
   static func unauthorized(_ code: APIErrorCode, message: String? = nil) -> Self {

--- a/Sources/App/API/EventScores.swift
+++ b/Sources/App/API/EventScores.swift
@@ -199,13 +199,15 @@ extension API {
     questionID: UUID,
     db: any Database.Connection.`Protocol`
   ) async throws -> [(UUID, QuestionScoreResult)] {
-    let correct = try await EventQuestionCorrectAnswerRecord
+    let correct =
+      try await EventQuestionCorrectAnswerRecord
       .where { $0.eventQuestionID.eq(questionID) }
       .limit(1)
       .fetchOne(db)
     guard let correct else { return [] }
 
-    let correctRevision = try await EventQuestionCorrectAnswerRevisionRecord
+    let correctRevision =
+      try await EventQuestionCorrectAnswerRevisionRecord
       .where { $0.eventQuestionCorrectAnswerID.eq(correct.id) }
       .order { ($0.createdAt.desc(), $0.id.desc()) }
       .limit(1)
@@ -247,7 +249,8 @@ extension API {
 
     var results: [(UUID, QuestionScoreResult)] = []
     for response in responses {
-      let revision = try await EventQuestionResponseRevisionRecord
+      let revision =
+        try await EventQuestionResponseRevisionRecord
         .where { $0.eventQuestionResponseID.eq(response.id) }
         .order { ($0.submittedAt.desc(), $0.id.desc()) }
         .limit(1)
@@ -313,7 +316,8 @@ enum RatingSettlement {
     database: PostgresClient
   ) async throws {
     try await database.withTransaction { db in
-      let season = try await RatingSeasonRecord
+      let season =
+        try await RatingSeasonRecord
         .where { $0.endsAt.is(nil) }
         .order { ($0.startsAt.desc(), $0.id.desc()) }
         .limit(1)

--- a/Sources/App/API/EventScores.swift
+++ b/Sources/App/API/EventScores.swift
@@ -1,0 +1,397 @@
+import Foundation
+import PostgresNIO
+import Records
+import StructuredQueriesPostgres
+import UUIDV7
+
+extension API {
+  func getEventScores(
+    _ input: Operations.GetEventScores.Input
+  ) async throws -> Operations.GetEventScores.Output {
+    guard let userID = UserTokenContext.currentUserID else { return .unauthorized }
+    guard let eventID = UUID(uuidString: input.path.eventId) else { return .badRequest }
+
+    do {
+      guard let event = try await latestEventSnapshot(eventID: eventID),
+        try await canViewEvent(event, userID: userID)
+      else {
+        return .notFound
+      }
+      let isOrganizer = event.event.organizerUserID == userID
+      guard isOrganizer || Date() >= event.revision.answersPublishedAt else {
+        return .forbidden
+      }
+      try await settleEventRatingsIfNeeded(eventID: eventID)
+
+      let scored = try await scoreEventParticipants(eventID: eventID)
+      let payload = scored.map { userID, questions in
+        let totalEarned = questions.reduce(0) { $0 + $1.result.earnedPoints }
+        let totalMax = questions.reduce(0) { $0 + $1.result.maxPoints }
+        return Components.Schemas.EventParticipantScore(
+          userID: userID.uuidString,
+          totalEarnedPoints: Int32(totalEarned),
+          totalMaxPoints: Int32(totalMax),
+          questionScores: questions.map { questionID, result in
+            Components.Schemas.QuestionScoreSummary(
+              eventQuestionID: questionID.uuidString,
+              earnedPoints: Int32(result.earnedPoints),
+              maxPoints: Int32(result.maxPoints),
+              performance: result.performance
+            )
+          }
+        )
+      }
+      return .ok(.init(body: .json(payload)))
+    } catch {
+      logEventDatabaseError(
+        "event.scores_failed",
+        "Failed to fetch event scores",
+        userID: userID,
+        error: error
+      )
+      return .badRequest
+    }
+  }
+
+  func getEventLeaderboard(
+    _ input: Operations.GetEventLeaderboard.Input
+  ) async throws -> Operations.GetEventLeaderboard.Output {
+    guard let userID = UserTokenContext.currentUserID else { return .unauthorized }
+    guard let eventID = UUID(uuidString: input.path.eventId) else { return .badRequest }
+
+    do {
+      guard let event = try await latestEventSnapshot(eventID: eventID),
+        try await canViewEvent(event, userID: userID)
+      else {
+        return .notFound
+      }
+      let isOrganizer = event.event.organizerUserID == userID
+      guard isOrganizer || Date() >= event.revision.answersPublishedAt else {
+        return .forbidden
+      }
+      try await settleEventRatingsIfNeeded(eventID: eventID)
+
+      let scored = try await scoreEventParticipants(eventID: eventID)
+      let ranked =
+        scored
+        .map { userID, questions in
+          (
+            userID: userID,
+            earned: questions.reduce(0) { $0 + $1.result.earnedPoints },
+            max: questions.reduce(0) { $0 + $1.result.maxPoints }
+          )
+        }
+        .sorted {
+          if $0.earned != $1.earned { return $0.earned > $1.earned }
+          return $0.userID.uuidString < $1.userID.uuidString
+        }
+      var entries: [Components.Schemas.EventLeaderboardEntry] = []
+      var rank: Int32 = 1
+      for row in ranked {
+        entries.append(
+          .init(
+            rank: rank,
+            userID: row.userID.uuidString,
+            totalEarnedPoints: Int32(row.earned),
+            totalMaxPoints: Int32(row.max)
+          )
+        )
+        rank += 1
+      }
+      return .ok(.init(body: .json(entries)))
+    } catch {
+      logEventDatabaseError(
+        "event.leaderboard_failed",
+        "Failed to fetch event leaderboard",
+        userID: userID,
+        error: error
+      )
+      return .badRequest
+    }
+  }
+
+  func getEventQuestionScores(
+    _ input: Operations.GetEventQuestionScores.Input
+  ) async throws -> Operations.GetEventQuestionScores.Output {
+    guard let userID = UserTokenContext.currentUserID else { return .unauthorized }
+    guard
+      let eventID = UUID(uuidString: input.path.eventId),
+      let questionID = UUID(uuidString: input.path.questionId)
+    else {
+      return .badRequest
+    }
+
+    do {
+      guard let event = try await latestEventSnapshot(eventID: eventID),
+        try await canViewEvent(event, userID: userID),
+        try await eventQuestionExists(questionID: questionID, eventID: eventID)
+      else {
+        return .notFound
+      }
+      let isOrganizer = event.event.organizerUserID == userID
+      guard isOrganizer || Date() >= event.revision.answersPublishedAt else {
+        return .forbidden
+      }
+      try await settleEventRatingsIfNeeded(eventID: eventID)
+
+      let questionScores = try await scoreQuestion(eventID: eventID, questionID: questionID)
+      let payload = questionScores.map { userID, result in
+        Components.Schemas.EventQuestionUserScore(
+          userID: userID.uuidString,
+          earnedPoints: Int32(result.earnedPoints),
+          maxPoints: Int32(result.maxPoints),
+          performance: result.performance,
+          components: result.components.map { component in
+            Components.Schemas.ScoreComponentResult(
+              component: .init(rawValue: component.component.rawValue)!,
+              earnedPoints: Int32(component.earnedPoints),
+              maxPoints: Int32(component.maxPoints)
+            )
+          }
+        )
+      }
+      return .ok(.init(body: .json(payload)))
+    } catch {
+      logEventDatabaseError(
+        "event.question_scores_failed",
+        "Failed to fetch question scores",
+        userID: userID,
+        error: error
+      )
+      return .badRequest
+    }
+  }
+}
+
+extension API {
+  func settleEventRatingsIfNeeded(eventID: UUID) async throws {
+    guard let event = try await latestEventSnapshot(eventID: eventID) else { return }
+    guard Date() >= event.revision.answersPublishedAt else { return }
+    try await RatingSettlement.settle(eventID: eventID, database: database)
+  }
+
+  func scoreEventParticipants(
+    eventID: UUID
+  ) async throws -> [(UUID, [(questionID: UUID, result: QuestionScoreResult)])] {
+    let questions = try await latestEventQuestionSnapshots(eventID: eventID)
+    var byUser: [UUID: [(questionID: UUID, result: QuestionScoreResult)]] = [:]
+    for question in questions {
+      let scores = try await scoreQuestion(eventID: eventID, questionID: question.question.id)
+      for (userID, result) in scores {
+        byUser[userID, default: []].append((question.question.id, result))
+      }
+    }
+    return byUser.keys.sorted { $0.uuidString < $1.uuidString }.map { userID in
+      (userID, byUser[userID] ?? [])
+    }
+  }
+
+  func scoreQuestion(
+    eventID: UUID,
+    questionID: UUID
+  ) async throws -> [(UUID, QuestionScoreResult)] {
+    try await database.read { db in
+      try await Self.scoreQuestion(questionID: questionID, db: db)
+    }
+  }
+
+  static func scoreQuestion(
+    questionID: UUID,
+    db: any Database.Connection.`Protocol`
+  ) async throws -> [(UUID, QuestionScoreResult)] {
+    let correct = try await EventQuestionCorrectAnswerRecord
+      .where { $0.eventQuestionID.eq(questionID) }
+      .limit(1)
+      .fetchOne(db)
+    guard let correct else { return [] }
+
+    let correctRevision = try await EventQuestionCorrectAnswerRevisionRecord
+      .where { $0.eventQuestionCorrectAnswerID.eq(correct.id) }
+      .order { ($0.createdAt.desc(), $0.id.desc()) }
+      .limit(1)
+      .fetchOne(db)
+    guard let correctRevision else { return [] }
+
+    let correctVarieties =
+      try await EventQuestionCorrectAnswerVarietyRecord
+      .where { $0.eventQuestionCorrectAnswerRevisionID.eq(correctRevision.id) }
+      .fetchAll(db)
+      .map(\.wineVarietyID)
+
+    let regionRules =
+      try await EventQuestionRegionScoreRuleRecord
+      .where { $0.eventQuestionID.eq(questionID) }
+      .fetchAll(db)
+    let componentRules =
+      try await EventQuestionScoreComponentRuleRecord
+      .where { $0.eventQuestionID.eq(questionID) }
+      .fetchAll(db)
+
+    let correctAncestors = try await regionAncestors(
+      regionID: correctRevision.wineRegionID,
+      db: db
+    )
+    let correctPayload = ScoringAnswerPayload(
+      wineRegionID: correctRevision.wineRegionID,
+      producerWineRegionID: correctRevision.producerWineRegionID,
+      feature: correctRevision.feature,
+      vintage: correctRevision.vintage,
+      alcoholByVolume: correctRevision.alcoholByVolume,
+      wineVarietyIDs: Set(correctVarieties)
+    )
+
+    let responses =
+      try await EventQuestionResponseRecord
+      .where { $0.eventQuestionID.eq(questionID) }
+      .fetchAll(db)
+
+    var results: [(UUID, QuestionScoreResult)] = []
+    for response in responses {
+      let revision = try await EventQuestionResponseRevisionRecord
+        .where { $0.eventQuestionResponseID.eq(response.id) }
+        .order { ($0.submittedAt.desc(), $0.id.desc()) }
+        .limit(1)
+        .fetchOne(db)
+      guard let revision else { continue }
+      let varieties =
+        try await EventQuestionResponseVarietyRecord
+        .where { $0.eventQuestionResponseRevisionID.eq(revision.id) }
+        .fetchAll(db)
+        .map(\.wineVarietyID)
+      let responseAncestors = try await regionAncestors(regionID: revision.wineRegionID, db: db)
+      let responsePayload = ScoringAnswerPayload(
+        wineRegionID: revision.wineRegionID,
+        producerWineRegionID: revision.producerWineRegionID,
+        feature: revision.feature,
+        vintage: revision.vintage,
+        alcoholByVolume: revision.alcoholByVolume,
+        wineVarietyIDs: Set(varieties)
+      )
+      let score = QuestionScorer.score(
+        correct: correctPayload,
+        response: responsePayload,
+        regionRules: regionRules,
+        componentRules: componentRules,
+        correctRegionAncestors: correctAncestors,
+        responseRegionAncestors: responseAncestors
+      )
+      results.append((response.userID, score))
+    }
+    return results.sorted { $0.0.uuidString < $1.0.uuidString }
+  }
+
+  static func regionAncestors(
+    regionID: UUID?,
+    db: any Database.Connection.`Protocol`
+  ) async throws -> [RegionAncestor] {
+    guard var currentID = regionID else { return [] }
+    var ancestors: [RegionAncestor] = []
+    var seen = Set<UUID>()
+    while seen.insert(currentID).inserted {
+      let region = try await WineRegionRecord.where { $0.id.eq(currentID) }.limit(1).fetchOne(db)
+      guard let region else { break }
+      ancestors.append(RegionAncestor(id: region.id, wineRegionTypeID: region.wineRegionTypeID))
+      guard let parent = region.parentRegionID else { break }
+      currentID = parent
+    }
+    return ancestors
+  }
+
+  func regionAncestors(
+    regionID: UUID?,
+    db: any Database.Connection.`Protocol`
+  ) async throws -> [RegionAncestor] {
+    try await Self.regionAncestors(regionID: regionID, db: db)
+  }
+}
+
+enum RatingSettlement {
+  static let initialRating = 1000
+
+  static func settle(
+    eventID: UUID,
+    database: PostgresClient
+  ) async throws {
+    try await database.withTransaction { db in
+      let season = try await RatingSeasonRecord
+        .where { $0.endsAt.is(nil) }
+        .order { ($0.startsAt.desc(), $0.id.desc()) }
+        .limit(1)
+        .fetchOne(db)
+      guard let season else { return }
+
+      let questions =
+        try await EventQuestionRecord
+        .where { $0.eventID.eq(eventID) }
+        .order { $0.questionNumber }
+        .fetchAll(db)
+
+      for question in questions {
+        let existing =
+          try await UserRatingLedgerRecord
+          .where {
+            $0.seasonID.eq(season.id)
+              .and($0.eventQuestionID.eq(question.id))
+          }
+          .limit(1)
+          .fetchOne(db)
+        if existing != nil { continue }
+
+        let scores = try await API.scoreQuestion(questionID: question.id, db: db)
+        guard !scores.isEmpty else { continue }
+        let average =
+          scores.map(\.1.performance).reduce(0, +) / Double(scores.count)
+
+        for (userID, result) in scores {
+          let delta = RatingCalculator.delta(
+            performance: result.performance,
+            fieldAverage: average
+          )
+          let current =
+            try await UserSeasonRatingRecord
+            .where {
+              $0.userID.eq(userID)
+                .and($0.seasonID.eq(season.id))
+            }
+            .limit(1)
+            .fetchOne(db)
+          let ratingBefore = current?.rating ?? initialRating
+          let ratingAfter = ratingBefore + delta
+          let now = Date()
+          if current != nil {
+            let updateQuery: QueryFragment = """
+              UPDATE public.user_season_ratings
+              SET rating = \(ratingAfter, as: Int.self),
+                  updated_at = \(now, as: Date.self)
+              WHERE user_id = \(userID, as: UUID.self)
+                AND season_id = \(season.id, as: UUID.self)
+              """
+            try await db.executeFragment(updateQuery)
+          } else {
+            try await UserSeasonRatingRecord.insert {
+              UserSeasonRatingRecord(
+                userID: userID,
+                seasonID: season.id,
+                rating: ratingAfter,
+                updatedAt: now
+              )
+            }.execute(db)
+          }
+          try await UserRatingLedgerRecord.insert {
+            UserRatingLedgerRecord(
+              id: UUID(uuidString: UUID.uuidV7String())!,
+              userID: userID,
+              seasonID: season.id,
+              eventQuestionID: question.id,
+              performance: result.performance,
+              fieldAverage: average,
+              delta: delta,
+              ratingAfter: ratingAfter,
+              createdAt: now
+            )
+          }.execute(db)
+        }
+      }
+    }
+  }
+}

--- a/Sources/App/API/EventScores.swift
+++ b/Sources/App/API/EventScores.swift
@@ -450,29 +450,36 @@ enum RatingSettlement {
     database: PostgresClient
   ) async throws {
     try await database.withTransaction { db in
-      let lockQuestion: QueryFragment =
-        "SELECT id FROM public.event_questions WHERE id = \(questionID, as: UUID.self) FOR UPDATE"
-      try await db.executeFragment(lockQuestion)
-
-      let entries =
-        try await UserRatingLedgerRecord
-        .where { $0.eventQuestionID.eq(questionID) }
-        .fetchAll(db)
-      let now = Date()
-      for entry in entries {
-        let reverse: QueryFragment = """
-          UPDATE public.user_season_ratings
-          SET rating = rating - \(entry.delta, as: Int.self),
-              updated_at = \(now, as: Date.self)
-          WHERE user_id = \(entry.userID, as: UUID.self)
-            AND season_id = \(entry.seasonID, as: UUID.self)
-          """
-        try await db.executeFragment(reverse)
-      }
-      let deleteLedger: QueryFragment =
-        "DELETE FROM public.user_rating_ledger WHERE event_question_id = \(questionID, as: UUID.self)"
-      try await db.executeFragment(deleteLedger)
+      try await invalidateQuestion(questionID: questionID, db: db)
     }
+  }
+
+  static func invalidateQuestion(
+    questionID: UUID,
+    db: any Database.Connection.`Protocol`
+  ) async throws {
+    let lockQuestion: QueryFragment =
+      "SELECT id FROM public.event_questions WHERE id = \(questionID, as: UUID.self) FOR UPDATE"
+    try await db.executeFragment(lockQuestion)
+
+    let entries =
+      try await UserRatingLedgerRecord
+      .where { $0.eventQuestionID.eq(questionID) }
+      .fetchAll(db)
+    let now = Date()
+    for entry in entries {
+      let reverse: QueryFragment = """
+        UPDATE public.user_season_ratings
+        SET rating = rating - \(entry.delta, as: Int.self),
+            updated_at = \(now, as: Date.self)
+        WHERE user_id = \(entry.userID, as: UUID.self)
+          AND season_id = \(entry.seasonID, as: UUID.self)
+        """
+      try await db.executeFragment(reverse)
+    }
+    let deleteLedger: QueryFragment =
+      "DELETE FROM public.user_rating_ledger WHERE event_question_id = \(questionID, as: UUID.self)"
+    try await db.executeFragment(deleteLedger)
   }
 
   static func seasonForSettlement(

--- a/Sources/App/API/EventScores.swift
+++ b/Sources/App/API/EventScores.swift
@@ -2,7 +2,6 @@ import Foundation
 import PostgresNIO
 import Records
 import StructuredQueriesPostgres
-import UUIDV7
 
 extension API {
   func getEventScores(
@@ -12,35 +11,34 @@ extension API {
     guard let eventID = UUID(uuidString: input.path.eventId) else { return .badRequest }
 
     do {
-      guard let event = try await latestEventSnapshot(eventID: eventID),
-        try await canViewEvent(event, userID: userID)
-      else {
-        return .notFound
-      }
-      guard try await canAccessEventScores(event, userID: userID) else {
-        return .forbidden
-      }
-      try await settleEventRatingsIfNeeded(eventID: eventID)
-
-      let scored = try await scoreEventParticipants(eventID: eventID)
-      let payload = scored.map { scoredUserID, questions in
-        let totalEarned = questions.reduce(0) { $0 + $1.result.earnedPoints }
-        let totalMax = questions.reduce(0) { $0 + $1.result.maxPoints }
-        return Components.Schemas.EventParticipantScore(
-          userID: scoredUserID.uuidString,
-          totalEarnedPoints: Int32(totalEarned),
-          totalMaxPoints: Int32(totalMax),
-          questionScores: questions.map { questionID, result in
-            Components.Schemas.QuestionScoreSummary(
-              eventQuestionID: questionID.uuidString,
-              earnedPoints: Int32(result.earnedPoints),
-              maxPoints: Int32(result.maxPoints),
-              performance: result.performance
-            )
-          }
+      switch try await authorizeEventScoresAccess(eventID: eventID, userID: userID) {
+      case .notFound: return .notFound
+      case .forbidden: return .forbidden
+      case .allowed(let event):
+        try await settleEventRatingsIfNeeded(event)
+        let scored = try await scoreEventParticipants(
+          eventID: eventID,
+          excludingUserID: event.event.organizerUserID
         )
+        let payload = scored.map { scoredUserID, questions in
+          let totalEarned = questions.reduce(0) { $0 + $1.result.earnedPoints }
+          let totalMax = questions.reduce(0) { $0 + $1.result.maxPoints }
+          return Components.Schemas.EventParticipantScore(
+            userID: scoredUserID.uuidString,
+            totalEarnedPoints: Int32(totalEarned),
+            totalMaxPoints: Int32(totalMax),
+            questionScores: questions.map { questionID, result in
+              Components.Schemas.QuestionScoreSummary(
+                eventQuestionID: questionID.uuidString,
+                earnedPoints: Int32(result.earnedPoints),
+                maxPoints: Int32(result.maxPoints),
+                performance: result.performance
+              )
+            }
+          )
+        }
+        return .ok(.init(body: .json(payload)))
       }
-      return .ok(.init(body: .json(payload)))
     } catch {
       logEventDatabaseError(
         "event.scores_failed",
@@ -59,39 +57,38 @@ extension API {
     guard let eventID = UUID(uuidString: input.path.eventId) else { return .badRequest }
 
     do {
-      guard let event = try await latestEventSnapshot(eventID: eventID),
-        try await canViewEvent(event, userID: userID)
-      else {
-        return .notFound
-      }
-      guard try await canAccessEventScores(event, userID: userID) else {
-        return .forbidden
-      }
-      try await settleEventRatingsIfNeeded(eventID: eventID)
-
-      let scored = try await scoreEventParticipants(eventID: eventID)
-      let ranked =
-        scored
-        .map { scoredUserID, questions in
-          (
-            userID: scoredUserID,
-            earned: questions.reduce(0) { $0 + $1.result.earnedPoints },
-            max: questions.reduce(0) { $0 + $1.result.maxPoints }
+      switch try await authorizeEventScoresAccess(eventID: eventID, userID: userID) {
+      case .notFound: return .notFound
+      case .forbidden: return .forbidden
+      case .allowed(let event):
+        try await settleEventRatingsIfNeeded(event)
+        let scored = try await scoreEventParticipants(
+          eventID: eventID,
+          excludingUserID: event.event.organizerUserID
+        )
+        let ranked =
+          scored
+          .map { scoredUserID, questions in
+            (
+              userID: scoredUserID,
+              earned: questions.reduce(0) { $0 + $1.result.earnedPoints },
+              max: questions.reduce(0) { $0 + $1.result.maxPoints }
+            )
+          }
+          .sorted {
+            if $0.earned != $1.earned { return $0.earned > $1.earned }
+            return $0.userID.uuidString < $1.userID.uuidString
+          }
+        let entries = Ranking.competitionRanks(ranked) { $0.earned }.map { rank, row in
+          Components.Schemas.EventLeaderboardEntry(
+            rank: rank,
+            userID: row.userID.uuidString,
+            totalEarnedPoints: Int32(row.earned),
+            totalMaxPoints: Int32(row.max)
           )
         }
-        .sorted {
-          if $0.earned != $1.earned { return $0.earned > $1.earned }
-          return $0.userID.uuidString < $1.userID.uuidString
-        }
-      let entries = Ranking.competitionRanks(ranked) { $0.earned }.map { rank, row in
-        Components.Schemas.EventLeaderboardEntry(
-          rank: rank,
-          userID: row.userID.uuidString,
-          totalEarnedPoints: Int32(row.earned),
-          totalMaxPoints: Int32(row.max)
-        )
+        return .ok(.init(body: .json(entries)))
       }
-      return .ok(.init(body: .json(entries)))
     } catch {
       logEventDatabaseError(
         "event.leaderboard_failed",
@@ -115,34 +112,35 @@ extension API {
     }
 
     do {
-      guard let event = try await latestEventSnapshot(eventID: eventID),
-        try await canViewEvent(event, userID: userID),
-        try await eventQuestionExists(questionID: questionID, eventID: eventID)
-      else {
-        return .notFound
+      switch try await authorizeEventScoresAccess(
+        eventID: eventID,
+        userID: userID,
+        questionID: questionID
+      ) {
+      case .notFound: return .notFound
+      case .forbidden: return .forbidden
+      case .allowed(let event):
+        try await settleEventRatingsIfNeeded(event)
+        let questionScores =
+          try await scoreQuestion(eventID: eventID, questionID: questionID)
+          .filter { $0.0 != event.event.organizerUserID }
+        let payload = questionScores.map { scoredUserID, result in
+          Components.Schemas.EventQuestionUserScore(
+            userID: scoredUserID.uuidString,
+            earnedPoints: Int32(result.earnedPoints),
+            maxPoints: Int32(result.maxPoints),
+            performance: result.performance,
+            components: result.components.map { component in
+              Components.Schemas.ScoreComponentResult(
+                component: .init(rawValue: component.component.rawValue)!,
+                earnedPoints: Int32(component.earnedPoints),
+                maxPoints: Int32(component.maxPoints)
+              )
+            }
+          )
+        }
+        return .ok(.init(body: .json(payload)))
       }
-      guard try await canAccessEventScores(event, userID: userID) else {
-        return .forbidden
-      }
-      try await settleEventRatingsIfNeeded(eventID: eventID)
-
-      let questionScores = try await scoreQuestion(eventID: eventID, questionID: questionID)
-      let payload = questionScores.map { scoredUserID, result in
-        Components.Schemas.EventQuestionUserScore(
-          userID: scoredUserID.uuidString,
-          earnedPoints: Int32(result.earnedPoints),
-          maxPoints: Int32(result.maxPoints),
-          performance: result.performance,
-          components: result.components.map { component in
-            Components.Schemas.ScoreComponentResult(
-              component: .init(rawValue: component.component.rawValue)!,
-              earnedPoints: Int32(component.earnedPoints),
-              maxPoints: Int32(component.maxPoints)
-            )
-          }
-        )
-      }
-      return .ok(.init(body: .json(payload)))
     } catch {
       logEventDatabaseError(
         "event.question_scores_failed",
@@ -156,6 +154,33 @@ extension API {
 }
 
 extension API {
+  enum EventScoresAccess {
+    case notFound
+    case forbidden
+    case allowed(EventSnapshot)
+  }
+
+  func authorizeEventScoresAccess(
+    eventID: UUID,
+    userID: UUID,
+    questionID: UUID? = nil
+  ) async throws -> EventScoresAccess {
+    guard let event = try await latestEventSnapshot(eventID: eventID),
+      try await canViewEvent(event, userID: userID)
+    else {
+      return .notFound
+    }
+    if let questionID {
+      guard try await eventQuestionExists(questionID: questionID, eventID: eventID) else {
+        return .notFound
+      }
+    }
+    guard try await canAccessEventScores(event, userID: userID) else {
+      return .forbidden
+    }
+    return .allowed(event)
+  }
+
   func canAccessEventScores(_ event: EventSnapshot, userID: UUID) async throws -> Bool {
     if event.event.organizerUserID == userID {
       return true
@@ -166,29 +191,26 @@ extension API {
     return try await activeParticipantExists(eventID: event.event.id, userID: userID)
   }
 
-  func settleEventRatingsIfNeeded(eventID: UUID) async throws {
-    guard let event = try await latestEventSnapshot(eventID: eventID) else { return }
+  func settleEventRatingsIfNeeded(_ event: EventSnapshot) async throws {
     guard Date() >= event.revision.answersPublishedAt else { return }
     try await RatingSettlement.settle(
-      eventID: eventID,
+      eventID: event.event.id,
       organizerUserID: event.event.organizerUserID,
       answersPublishedAt: event.revision.answersPublishedAt,
       database: database
     )
   }
 
-  func invalidateQuestionRating(questionID: UUID) async throws {
-    try await RatingSettlement.invalidateQuestion(questionID: questionID, database: database)
-  }
-
   func scoreEventParticipants(
-    eventID: UUID
+    eventID: UUID,
+    excludingUserID: UUID? = nil
   ) async throws -> [(UUID, [(questionID: UUID, result: QuestionScoreResult)])] {
     let questions = try await latestEventQuestionSnapshots(eventID: eventID)
     var byUser: [UUID: [(questionID: UUID, result: QuestionScoreResult)]] = [:]
     for question in questions {
       let scores = try await scoreQuestion(eventID: eventID, questionID: question.question.id)
       for (scoredUserID, result) in scores {
+        if scoredUserID == excludingUserID { continue }
         byUser[scoredUserID, default: []].append((question.question.id, result))
       }
     }
@@ -272,7 +294,7 @@ extension API {
       }
     }
 
-    let revisionIDs = latestRevisionByResponseID.values.map(\.id)
+    let revisionIDs = Array(latestRevisionByResponseID.values.map(\.id))
     let allVarieties: [EventQuestionResponseVarietyRecord]
     if revisionIDs.isEmpty {
       allVarieties = []
@@ -338,164 +360,5 @@ extension API {
       currentID = parent
     }
     return ancestors
-  }
-
-  func regionAncestors(
-    regionID: UUID?,
-    db: any Database.Connection.`Protocol`
-  ) async throws -> [RegionAncestor] {
-    try await Self.regionAncestors(regionID: regionID, db: db)
-  }
-}
-
-enum RatingSettlement {
-  static let initialRating = 1000
-
-  static func settle(
-    eventID: UUID,
-    organizerUserID: UUID,
-    answersPublishedAt: Date,
-    database: PostgresClient
-  ) async throws {
-    try await database.withTransaction { db in
-      let lockEvent: QueryFragment =
-        "SELECT id FROM public.events WHERE id = \(eventID, as: UUID.self) FOR UPDATE"
-      try await db.executeFragment(lockEvent)
-
-      guard
-        let season = try await seasonForSettlement(at: answersPublishedAt, db: db)
-      else {
-        return
-      }
-
-      let questions =
-        try await EventQuestionRecord
-        .where { $0.eventID.eq(eventID) }
-        .order { $0.questionNumber }
-        .fetchAll(db)
-
-      for question in questions {
-        let lockQuestion: QueryFragment =
-          "SELECT id FROM public.event_questions WHERE id = \(question.id, as: UUID.self) FOR UPDATE"
-        try await db.executeFragment(lockQuestion)
-
-        let existing =
-          try await UserRatingLedgerRecord
-          .where {
-            $0.seasonID.eq(season.id)
-              .and($0.eventQuestionID.eq(question.id))
-          }
-          .limit(1)
-          .fetchOne(db)
-        if existing != nil { continue }
-
-        let scores =
-          try await API.scoreQuestion(questionID: question.id, db: db)
-          .filter { $0.0 != organizerUserID }
-        guard !scores.isEmpty else { continue }
-        let average =
-          scores.map(\.1.performance).reduce(0, +) / Double(scores.count)
-
-        for (userID, result) in scores {
-          let delta = RatingCalculator.delta(
-            performance: result.performance,
-            fieldAverage: average
-          )
-          let now = Date()
-          let upsert: QueryFragment = """
-            INSERT INTO public.user_season_ratings (user_id, season_id, rating, updated_at)
-            VALUES (
-              \(userID, as: UUID.self),
-              \(season.id, as: UUID.self),
-              \(initialRating + delta, as: Int.self),
-              \(now, as: Date.self)
-            )
-            ON CONFLICT (user_id, season_id) DO UPDATE
-            SET rating = public.user_season_ratings.rating + \(delta, as: Int.self),
-                updated_at = EXCLUDED.updated_at
-            """
-          try await db.executeFragment(upsert)
-
-          let ratingAfter =
-            try await UserSeasonRatingRecord
-            .where {
-              $0.userID.eq(userID)
-                .and($0.seasonID.eq(season.id))
-            }
-            .limit(1)
-            .fetchOne(db)?
-            .rating ?? (initialRating + delta)
-
-          try await UserRatingLedgerRecord.insert {
-            UserRatingLedgerRecord(
-              id: UUID(uuidString: UUID.uuidV7String())!,
-              userID: userID,
-              seasonID: season.id,
-              eventQuestionID: question.id,
-              performance: result.performance,
-              fieldAverage: average,
-              delta: delta,
-              ratingAfter: ratingAfter,
-              createdAt: now
-            )
-          }.execute(db)
-        }
-      }
-    }
-  }
-
-  /// Reverses rating deltas and deletes ledger rows for a question so it can be settled again.
-  static func invalidateQuestion(
-    questionID: UUID,
-    database: PostgresClient
-  ) async throws {
-    try await database.withTransaction { db in
-      try await invalidateQuestion(questionID: questionID, db: db)
-    }
-  }
-
-  static func invalidateQuestion(
-    questionID: UUID,
-    db: any Database.Connection.`Protocol`
-  ) async throws {
-    let lockQuestion: QueryFragment =
-      "SELECT id FROM public.event_questions WHERE id = \(questionID, as: UUID.self) FOR UPDATE"
-    try await db.executeFragment(lockQuestion)
-
-    let entries =
-      try await UserRatingLedgerRecord
-      .where { $0.eventQuestionID.eq(questionID) }
-      .fetchAll(db)
-    let now = Date()
-    for entry in entries {
-      let reverse: QueryFragment = """
-        UPDATE public.user_season_ratings
-        SET rating = rating - \(entry.delta, as: Int.self),
-            updated_at = \(now, as: Date.self)
-        WHERE user_id = \(entry.userID, as: UUID.self)
-          AND season_id = \(entry.seasonID, as: UUID.self)
-        """
-      try await db.executeFragment(reverse)
-    }
-    let deleteLedger: QueryFragment =
-      "DELETE FROM public.user_rating_ledger WHERE event_question_id = \(questionID, as: UUID.self)"
-    try await db.executeFragment(deleteLedger)
-  }
-
-  static func seasonForSettlement(
-    at publishedAt: Date,
-    db: any Database.Connection.`Protocol`
-  ) async throws -> RatingSeasonRecord? {
-    let seasons =
-      try await RatingSeasonRecord
-      .order { ($0.startsAt.desc(), $0.id.desc()) }
-      .fetchAll(db)
-    return seasons.first { season in
-      guard season.startsAt <= publishedAt else { return false }
-      if let endsAt = season.endsAt {
-        return endsAt > publishedAt
-      }
-      return true
-    }
   }
 }

--- a/Sources/App/API/EventScores.swift
+++ b/Sources/App/API/EventScores.swift
@@ -17,18 +17,17 @@ extension API {
       else {
         return .notFound
       }
-      let isOrganizer = event.event.organizerUserID == userID
-      guard isOrganizer || Date() >= event.revision.answersPublishedAt else {
+      guard try await canAccessEventScores(event, userID: userID) else {
         return .forbidden
       }
       try await settleEventRatingsIfNeeded(eventID: eventID)
 
       let scored = try await scoreEventParticipants(eventID: eventID)
-      let payload = scored.map { userID, questions in
+      let payload = scored.map { scoredUserID, questions in
         let totalEarned = questions.reduce(0) { $0 + $1.result.earnedPoints }
         let totalMax = questions.reduce(0) { $0 + $1.result.maxPoints }
         return Components.Schemas.EventParticipantScore(
-          userID: userID.uuidString,
+          userID: scoredUserID.uuidString,
           totalEarnedPoints: Int32(totalEarned),
           totalMaxPoints: Int32(totalMax),
           questionScores: questions.map { questionID, result in
@@ -65,8 +64,7 @@ extension API {
       else {
         return .notFound
       }
-      let isOrganizer = event.event.organizerUserID == userID
-      guard isOrganizer || Date() >= event.revision.answersPublishedAt else {
+      guard try await canAccessEventScores(event, userID: userID) else {
         return .forbidden
       }
       try await settleEventRatingsIfNeeded(eventID: eventID)
@@ -74,9 +72,9 @@ extension API {
       let scored = try await scoreEventParticipants(eventID: eventID)
       let ranked =
         scored
-        .map { userID, questions in
+        .map { scoredUserID, questions in
           (
-            userID: userID,
+            userID: scoredUserID,
             earned: questions.reduce(0) { $0 + $1.result.earnedPoints },
             max: questions.reduce(0) { $0 + $1.result.maxPoints }
           )
@@ -85,18 +83,13 @@ extension API {
           if $0.earned != $1.earned { return $0.earned > $1.earned }
           return $0.userID.uuidString < $1.userID.uuidString
         }
-      var entries: [Components.Schemas.EventLeaderboardEntry] = []
-      var rank: Int32 = 1
-      for row in ranked {
-        entries.append(
-          .init(
-            rank: rank,
-            userID: row.userID.uuidString,
-            totalEarnedPoints: Int32(row.earned),
-            totalMaxPoints: Int32(row.max)
-          )
+      let entries = Ranking.competitionRanks(ranked) { $0.earned }.map { rank, row in
+        Components.Schemas.EventLeaderboardEntry(
+          rank: rank,
+          userID: row.userID.uuidString,
+          totalEarnedPoints: Int32(row.earned),
+          totalMaxPoints: Int32(row.max)
         )
-        rank += 1
       }
       return .ok(.init(body: .json(entries)))
     } catch {
@@ -128,16 +121,15 @@ extension API {
       else {
         return .notFound
       }
-      let isOrganizer = event.event.organizerUserID == userID
-      guard isOrganizer || Date() >= event.revision.answersPublishedAt else {
+      guard try await canAccessEventScores(event, userID: userID) else {
         return .forbidden
       }
       try await settleEventRatingsIfNeeded(eventID: eventID)
 
       let questionScores = try await scoreQuestion(eventID: eventID, questionID: questionID)
-      let payload = questionScores.map { userID, result in
+      let payload = questionScores.map { scoredUserID, result in
         Components.Schemas.EventQuestionUserScore(
-          userID: userID.uuidString,
+          userID: scoredUserID.uuidString,
           earnedPoints: Int32(result.earnedPoints),
           maxPoints: Int32(result.maxPoints),
           performance: result.performance,
@@ -164,10 +156,29 @@ extension API {
 }
 
 extension API {
+  func canAccessEventScores(_ event: EventSnapshot, userID: UUID) async throws -> Bool {
+    if event.event.organizerUserID == userID {
+      return true
+    }
+    guard Date() >= event.revision.answersPublishedAt else {
+      return false
+    }
+    return try await activeParticipantExists(eventID: event.event.id, userID: userID)
+  }
+
   func settleEventRatingsIfNeeded(eventID: UUID) async throws {
     guard let event = try await latestEventSnapshot(eventID: eventID) else { return }
     guard Date() >= event.revision.answersPublishedAt else { return }
-    try await RatingSettlement.settle(eventID: eventID, database: database)
+    try await RatingSettlement.settle(
+      eventID: eventID,
+      organizerUserID: event.event.organizerUserID,
+      answersPublishedAt: event.revision.answersPublishedAt,
+      database: database
+    )
+  }
+
+  func invalidateQuestionRating(questionID: UUID) async throws {
+    try await RatingSettlement.invalidateQuestion(questionID: questionID, database: database)
   }
 
   func scoreEventParticipants(
@@ -177,12 +188,12 @@ extension API {
     var byUser: [UUID: [(questionID: UUID, result: QuestionScoreResult)]] = [:]
     for question in questions {
       let scores = try await scoreQuestion(eventID: eventID, questionID: question.question.id)
-      for (userID, result) in scores {
-        byUser[userID, default: []].append((question.question.id, result))
+      for (scoredUserID, result) in scores {
+        byUser[scoredUserID, default: []].append((question.question.id, result))
       }
     }
-    return byUser.keys.sorted { $0.uuidString < $1.uuidString }.map { userID in
-      (userID, byUser[userID] ?? [])
+    return byUser.keys.sorted { $0.uuidString < $1.uuidString }.map { scoredUserID in
+      (scoredUserID, byUser[scoredUserID] ?? [])
     }
   }
 
@@ -246,22 +257,51 @@ extension API {
       try await EventQuestionResponseRecord
       .where { $0.eventQuestionID.eq(questionID) }
       .fetchAll(db)
+    guard !responses.isEmpty else { return [] }
 
+    let responseIDs = responses.map(\.id)
+    let allRevisions =
+      try await EventQuestionResponseRevisionRecord
+      .where { $0.eventQuestionResponseID.in(responseIDs) }
+      .order { ($0.submittedAt.desc(), $0.id.desc()) }
+      .fetchAll(db)
+    var latestRevisionByResponseID: [UUID: EventQuestionResponseRevisionRecord] = [:]
+    for revision in allRevisions {
+      if latestRevisionByResponseID[revision.eventQuestionResponseID] == nil {
+        latestRevisionByResponseID[revision.eventQuestionResponseID] = revision
+      }
+    }
+
+    let revisionIDs = latestRevisionByResponseID.values.map(\.id)
+    let allVarieties: [EventQuestionResponseVarietyRecord]
+    if revisionIDs.isEmpty {
+      allVarieties = []
+    } else {
+      allVarieties =
+        try await EventQuestionResponseVarietyRecord
+        .where { $0.eventQuestionResponseRevisionID.in(revisionIDs) }
+        .fetchAll(db)
+    }
+    let varietiesByRevisionID = Dictionary(
+      grouping: allVarieties, by: \.eventQuestionResponseRevisionID)
+
+    var ancestorCache: [UUID: [RegionAncestor]] = [:]
     var results: [(UUID, QuestionScoreResult)] = []
     for response in responses {
-      let revision =
-        try await EventQuestionResponseRevisionRecord
-        .where { $0.eventQuestionResponseID.eq(response.id) }
-        .order { ($0.submittedAt.desc(), $0.id.desc()) }
-        .limit(1)
-        .fetchOne(db)
-      guard let revision else { continue }
-      let varieties =
-        try await EventQuestionResponseVarietyRecord
-        .where { $0.eventQuestionResponseRevisionID.eq(revision.id) }
-        .fetchAll(db)
-        .map(\.wineVarietyID)
-      let responseAncestors = try await regionAncestors(regionID: revision.wineRegionID, db: db)
+      guard let revision = latestRevisionByResponseID[response.id] else { continue }
+      let varieties = varietiesByRevisionID[revision.id, default: []].map(\.wineVarietyID)
+      let responseAncestors: [RegionAncestor]
+      if let regionID = revision.wineRegionID {
+        if let cached = ancestorCache[regionID] {
+          responseAncestors = cached
+        } else {
+          let loaded = try await regionAncestors(regionID: regionID, db: db)
+          ancestorCache[regionID] = loaded
+          responseAncestors = loaded
+        }
+      } else {
+        responseAncestors = []
+      }
       let responsePayload = ScoringAnswerPayload(
         wineRegionID: revision.wineRegionID,
         producerWineRegionID: revision.producerWineRegionID,
@@ -313,16 +353,20 @@ enum RatingSettlement {
 
   static func settle(
     eventID: UUID,
+    organizerUserID: UUID,
+    answersPublishedAt: Date,
     database: PostgresClient
   ) async throws {
     try await database.withTransaction { db in
-      let season =
-        try await RatingSeasonRecord
-        .where { $0.endsAt.is(nil) }
-        .order { ($0.startsAt.desc(), $0.id.desc()) }
-        .limit(1)
-        .fetchOne(db)
-      guard let season else { return }
+      let lockEvent: QueryFragment =
+        "SELECT id FROM public.events WHERE id = \(eventID, as: UUID.self) FOR UPDATE"
+      try await db.executeFragment(lockEvent)
+
+      guard
+        let season = try await seasonForSettlement(at: answersPublishedAt, db: db)
+      else {
+        return
+      }
 
       let questions =
         try await EventQuestionRecord
@@ -331,6 +375,10 @@ enum RatingSettlement {
         .fetchAll(db)
 
       for question in questions {
+        let lockQuestion: QueryFragment =
+          "SELECT id FROM public.event_questions WHERE id = \(question.id, as: UUID.self) FOR UPDATE"
+        try await db.executeFragment(lockQuestion)
+
         let existing =
           try await UserRatingLedgerRecord
           .where {
@@ -341,7 +389,9 @@ enum RatingSettlement {
           .fetchOne(db)
         if existing != nil { continue }
 
-        let scores = try await API.scoreQuestion(questionID: question.id, db: db)
+        let scores =
+          try await API.scoreQuestion(questionID: question.id, db: db)
+          .filter { $0.0 != organizerUserID }
         guard !scores.isEmpty else { continue }
         let average =
           scores.map(\.1.performance).reduce(0, +) / Double(scores.count)
@@ -351,36 +401,31 @@ enum RatingSettlement {
             performance: result.performance,
             fieldAverage: average
           )
-          let current =
+          let now = Date()
+          let upsert: QueryFragment = """
+            INSERT INTO public.user_season_ratings (user_id, season_id, rating, updated_at)
+            VALUES (
+              \(userID, as: UUID.self),
+              \(season.id, as: UUID.self),
+              \(initialRating + delta, as: Int.self),
+              \(now, as: Date.self)
+            )
+            ON CONFLICT (user_id, season_id) DO UPDATE
+            SET rating = public.user_season_ratings.rating + \(delta, as: Int.self),
+                updated_at = EXCLUDED.updated_at
+            """
+          try await db.executeFragment(upsert)
+
+          let ratingAfter =
             try await UserSeasonRatingRecord
             .where {
               $0.userID.eq(userID)
                 .and($0.seasonID.eq(season.id))
             }
             .limit(1)
-            .fetchOne(db)
-          let ratingBefore = current?.rating ?? initialRating
-          let ratingAfter = ratingBefore + delta
-          let now = Date()
-          if current != nil {
-            let updateQuery: QueryFragment = """
-              UPDATE public.user_season_ratings
-              SET rating = \(ratingAfter, as: Int.self),
-                  updated_at = \(now, as: Date.self)
-              WHERE user_id = \(userID, as: UUID.self)
-                AND season_id = \(season.id, as: UUID.self)
-              """
-            try await db.executeFragment(updateQuery)
-          } else {
-            try await UserSeasonRatingRecord.insert {
-              UserSeasonRatingRecord(
-                userID: userID,
-                seasonID: season.id,
-                rating: ratingAfter,
-                updatedAt: now
-              )
-            }.execute(db)
-          }
+            .fetchOne(db)?
+            .rating ?? (initialRating + delta)
+
           try await UserRatingLedgerRecord.insert {
             UserRatingLedgerRecord(
               id: UUID(uuidString: UUID.uuidV7String())!,
@@ -396,6 +441,54 @@ enum RatingSettlement {
           }.execute(db)
         }
       }
+    }
+  }
+
+  /// Reverses rating deltas and deletes ledger rows for a question so it can be settled again.
+  static func invalidateQuestion(
+    questionID: UUID,
+    database: PostgresClient
+  ) async throws {
+    try await database.withTransaction { db in
+      let lockQuestion: QueryFragment =
+        "SELECT id FROM public.event_questions WHERE id = \(questionID, as: UUID.self) FOR UPDATE"
+      try await db.executeFragment(lockQuestion)
+
+      let entries =
+        try await UserRatingLedgerRecord
+        .where { $0.eventQuestionID.eq(questionID) }
+        .fetchAll(db)
+      let now = Date()
+      for entry in entries {
+        let reverse: QueryFragment = """
+          UPDATE public.user_season_ratings
+          SET rating = rating - \(entry.delta, as: Int.self),
+              updated_at = \(now, as: Date.self)
+          WHERE user_id = \(entry.userID, as: UUID.self)
+            AND season_id = \(entry.seasonID, as: UUID.self)
+          """
+        try await db.executeFragment(reverse)
+      }
+      let deleteLedger: QueryFragment =
+        "DELETE FROM public.user_rating_ledger WHERE event_question_id = \(questionID, as: UUID.self)"
+      try await db.executeFragment(deleteLedger)
+    }
+  }
+
+  static func seasonForSettlement(
+    at publishedAt: Date,
+    db: any Database.Connection.`Protocol`
+  ) async throws -> RatingSeasonRecord? {
+    let seasons =
+      try await RatingSeasonRecord
+      .order { ($0.startsAt.desc(), $0.id.desc()) }
+      .fetchAll(db)
+    return seasons.first { season in
+      guard season.startsAt <= publishedAt else { return false }
+      if let endsAt = season.endsAt {
+        return endsAt > publishedAt
+      }
+      return true
     }
   }
 }

--- a/Sources/App/API/Events.swift
+++ b/Sources/App/API/Events.swift
@@ -7,15 +7,16 @@ import StructuredQueriesPostgres
 import UUIDV7
 import Valkey
 
-private struct EventSnapshot {
+struct EventSnapshot {
   var event: EventRecord
   var revision: EventRevisionRecord
-  var regionScoreRules: [EventRegionScoreRuleRecord]
 }
 
-private struct EventQuestionSnapshot {
+struct EventQuestionSnapshot {
   var question: EventQuestionRecord
   var revision: EventQuestionRevisionRecord
+  var regionScoreRules: [EventQuestionRegionScoreRuleRecord]
+  var scoreComponentRules: [EventQuestionScoreComponentRuleRecord]
 }
 
 private enum EventRegistrationError: Error {
@@ -128,9 +129,6 @@ extension API {
     guard let revision = eventRevisionRecord(from: body, eventID: eventID) else {
       return .badRequest
     }
-    guard let regionScoreRules = eventRegionScoreRuleRecords(from: body, eventID: eventID) else {
-      return .badRequest
-    }
     let event = EventRecord(id: eventID, organizerUserID: userID, createdAt: Date())
 
     do {
@@ -142,15 +140,12 @@ extension API {
       try await database.withTransaction { db in
         try await EventRecord.insert { event }.execute(db)
         try await EventRevisionRecord.insert { revision }.execute(db)
-        if !regionScoreRules.isEmpty {
-          try await EventRegionScoreRuleRecord.insert { regionScoreRules }.execute(db)
-        }
       }
       return .ok(
         .init(
           body: .json(
             await makeEvent(
-              EventSnapshot(event: event, revision: revision, regionScoreRules: regionScoreRules)
+              EventSnapshot(event: event, revision: revision)
             )
           )
         )
@@ -222,9 +217,6 @@ extension API {
       else {
         return .badRequest
       }
-      guard let regionScoreRules = eventRegionScoreRuleRecords(from: body, eventID: eventID) else {
-        return .badRequest
-      }
       if let imageID = revision.imageID {
         guard try await ownedImageExists(imageID: imageID, userID: userID) else {
           return .badRequest
@@ -232,7 +224,6 @@ extension API {
       }
       try await database.withTransaction { db in
         try await EventRevisionRecord.insert { revision }.execute(db)
-        try await replaceEventRegionScoreRules(regionScoreRules, eventID: eventID, db: db)
       }
       return .ok(
         .init(
@@ -240,8 +231,7 @@ extension API {
             await makeEvent(
               EventSnapshot(
                 event: current.event,
-                revision: revision,
-                regionScoreRules: regionScoreRules
+                revision: revision
               )
             )
           )
@@ -335,6 +325,19 @@ extension API {
     guard validImageID, body.questionNumber > 0 else {
       return .badRequest
     }
+    let questionID = UUID(uuidString: UUID.uuidV7String())!
+    guard
+      let regionScoreRules = questionRegionScoreRuleRecords(
+        from: body.regionScoreRules,
+        questionID: questionID
+      ),
+      let scoreComponentRules = questionScoreComponentRuleRecords(
+        from: body.scoreComponentRules,
+        questionID: questionID
+      )
+    else {
+      return .badRequest
+    }
 
     do {
       guard try await isEventOrganizer(eventID: eventID, userID: userID) else {
@@ -346,7 +349,7 @@ extension API {
         }
       }
       let question = EventQuestionRecord(
-        id: UUID(uuidString: UUID.uuidV7String())!,
+        id: questionID,
         eventID: eventID,
         questionNumber: Int(body.questionNumber),
         createdAt: Date()
@@ -361,12 +364,24 @@ extension API {
       try await database.withTransaction { db in
         try await EventQuestionRecord.insert { question }.execute(db)
         try await EventQuestionRevisionRecord.insert { revision }.execute(db)
+        if !regionScoreRules.isEmpty {
+          try await EventQuestionRegionScoreRuleRecord.insert { regionScoreRules }.execute(db)
+        }
+        if !scoreComponentRules.isEmpty {
+          try await EventQuestionScoreComponentRuleRecord.insert { scoreComponentRules }
+            .execute(db)
+        }
       }
       return .ok(
         .init(
           body: .json(
             await makeEventQuestion(
-              EventQuestionSnapshot(question: question, revision: revision)
+              EventQuestionSnapshot(
+                question: question,
+                revision: revision,
+                regionScoreRules: regionScoreRules,
+                scoreComponentRules: scoreComponentRules
+              )
             )
           )
         )
@@ -399,6 +414,18 @@ extension API {
     guard validImageID, body.questionNumber > 0 else {
       return .badRequest
     }
+    guard
+      let regionScoreRules = questionRegionScoreRuleRecords(
+        from: body.regionScoreRules,
+        questionID: questionID
+      ),
+      let scoreComponentRules = questionScoreComponentRuleRecords(
+        from: body.scoreComponentRules,
+        questionID: questionID
+      )
+    else {
+      return .badRequest
+    }
 
     do {
       guard try await isEventOrganizer(eventID: eventID, userID: userID),
@@ -421,14 +448,25 @@ extension API {
         note: body.note,
         createdAt: Date()
       )
-      try await database.write { db in
+      try await database.withTransaction { db in
         try await EventQuestionRevisionRecord.insert { revision }.execute(db)
+        try await replaceQuestionScoreRules(
+          regionScoreRules: regionScoreRules,
+          scoreComponentRules: scoreComponentRules,
+          questionID: questionID,
+          db: db
+        )
       }
       return .ok(
         .init(
           body: .json(
             await makeEventQuestion(
-              EventQuestionSnapshot(question: question, revision: revision)
+              EventQuestionSnapshot(
+                question: question,
+                revision: revision,
+                regionScoreRules: regionScoreRules,
+                scoreComponentRules: scoreComponentRules
+              )
             )
           )
         )
@@ -459,8 +497,11 @@ extension API {
       return .badRequest
     }
     let (regionID, validRegionID) = parseOptionalUUID(body.wineRegionID)
+    let (producerWineRegionID, validProducerWineRegionID) = parseOptionalUUID(
+      body.producerWineRegionID
+    )
     guard
-      validRegionID, isValidVintage(body.vintage),
+      validRegionID, validProducerWineRegionID, isValidVintage(body.vintage),
       isValidAlcoholByVolume(body.alcoholByVolume)
     else {
       return .badRequest
@@ -475,6 +516,8 @@ extension API {
       let result = try await insertCorrectAnswer(
         questionID: questionID,
         regionID: regionID,
+        producerWineRegionID: producerWineRegionID,
+        feature: body.feature,
         vintage: body.vintage.map(Int.init),
         alcoholByVolume: body.alcoholByVolume,
         varietyIDs: varietyIDs,
@@ -516,8 +559,11 @@ extension API {
       return .badRequest
     }
     let (regionID, validRegionID) = parseOptionalUUID(body.wineRegionID)
+    let (producerWineRegionID, validProducerWineRegionID) = parseOptionalUUID(
+      body.producerWineRegionID
+    )
     guard
-      validRegionID, isValidVintage(body.vintage),
+      validRegionID, validProducerWineRegionID, isValidVintage(body.vintage),
       isValidAlcoholByVolume(body.alcoholByVolume)
     else {
       return .badRequest
@@ -533,6 +579,8 @@ extension API {
       let result = try await insertCorrectAnswer(
         questionID: questionID,
         regionID: regionID,
+        producerWineRegionID: producerWineRegionID,
+        feature: body.feature,
         vintage: body.vintage.map(Int.init),
         alcoholByVolume: body.alcoholByVolume,
         varietyIDs: varietyIDs,
@@ -574,8 +622,11 @@ extension API {
       return .badRequest
     }
     let (regionID, validRegionID) = parseOptionalUUID(body.wineRegionID)
+    let (producerWineRegionID, validProducerWineRegionID) = parseOptionalUUID(
+      body.producerWineRegionID
+    )
     guard
-      validRegionID, isValidVintage(body.vintage),
+      validRegionID, validProducerWineRegionID, isValidVintage(body.vintage),
       isValidAlcoholByVolume(body.alcoholByVolume)
     else {
       return .badRequest
@@ -591,6 +642,8 @@ extension API {
         questionID: questionID,
         userID: userID,
         regionID: regionID,
+        producerWineRegionID: producerWineRegionID,
+        feature: body.feature,
         vintage: body.vintage.map(Int.init),
         alcoholByVolume: body.alcoholByVolume,
         note: body.note,
@@ -633,8 +686,11 @@ extension API {
       return .badRequest
     }
     let (regionID, validRegionID) = parseOptionalUUID(body.wineRegionID)
+    let (producerWineRegionID, validProducerWineRegionID) = parseOptionalUUID(
+      body.producerWineRegionID
+    )
     guard
-      validRegionID, isValidVintage(body.vintage),
+      validRegionID, validProducerWineRegionID, isValidVintage(body.vintage),
       isValidAlcoholByVolume(body.alcoholByVolume)
     else {
       return .badRequest
@@ -651,6 +707,8 @@ extension API {
         questionID: questionID,
         userID: userID,
         regionID: regionID,
+        producerWineRegionID: producerWineRegionID,
+        feature: body.feature,
         vintage: body.vintage.map(Int.init),
         alcoholByVolume: body.alcoholByVolume,
         note: body.note,
@@ -846,8 +904,7 @@ extension API {
       if event.event.organizerUserID != userID {
         // Participants may only see the correct answer once it has been published.
         guard try await canViewEvent(event, userID: userID),
-          let answersPublishedAt = event.revision.answersPublishedAt,
-          Date() >= answersPublishedAt
+          Date() >= event.revision.answersPublishedAt
         else {
           return .notFound
         }
@@ -1082,6 +1139,11 @@ extension API {
       return nil
     }
     guard body.eventPeriod.startsAt < body.eventPeriod.endsAt else { return nil }
+    let startsAt = Date(timeIntervalSinceReferenceDate: body.eventPeriod.startsAt)
+    let endsAt = Date(timeIntervalSinceReferenceDate: body.eventPeriod.endsAt)
+    let responsesDueAt = Date(timeIntervalSinceReferenceDate: body.responsesDueAt)
+    let answersPublishedAt = Date(timeIntervalSinceReferenceDate: body.answersPublishedAt)
+    guard startsAt <= responsesDueAt, responsesDueAt <= answersPublishedAt else { return nil }
     if let registrationPeriod = body.registrationPeriod,
       registrationPeriod.startsAt >= registrationPeriod.endsAt
     {
@@ -1128,9 +1190,10 @@ extension API {
       registrationEndsAt: body.registrationPeriod.map {
         Date(timeIntervalSinceReferenceDate: $0.endsAt)
       },
-      startsAt: Date(timeIntervalSinceReferenceDate: body.eventPeriod.startsAt),
-      endsAt: Date(timeIntervalSinceReferenceDate: body.eventPeriod.endsAt),
-      answersPublishedAt: body.answersPublishedAt.map(Date.init(timeIntervalSinceReferenceDate:)),
+      startsAt: startsAt,
+      endsAt: endsAt,
+      responsesDueAt: responsesDueAt,
+      answersPublishedAt: answersPublishedAt,
       capacity: body.capacity.map(Int.init),
       entryFeeMinorAmount: body.entryFee?.minorAmount,
       entryFeeCurrencyCode: body.entryFee?.currencyCode.trimmingCharacters(
@@ -1143,11 +1206,11 @@ extension API {
     )
   }
 
-  fileprivate func eventRegionScoreRuleRecords(
-    from body: Components.Schemas.CreateEventRequest,
-    eventID: UUID
-  ) -> [EventRegionScoreRuleRecord]? {
-    let rules = body.regionScoreRules ?? []
+  fileprivate func questionRegionScoreRuleRecords(
+    from rules: [Components.Schemas.CreateQuestionRegionScoreRuleRequest]?,
+    questionID: UUID
+  ) -> [EventQuestionRegionScoreRuleRecord]? {
+    let rules = rules ?? []
     let wineRegionTypeIDs = rules.compactMap { UUID(uuidString: $0.wineRegionTypeID) }
     guard wineRegionTypeIDs.count == rules.count,
       Set(wineRegionTypeIDs).count == wineRegionTypeIDs.count
@@ -1157,8 +1220,8 @@ extension API {
     guard rules.allSatisfy({ $0.points >= 0 }) else { return nil }
     let now = Date()
     return zip(rules, wineRegionTypeIDs).map { rule, wineRegionTypeID in
-      EventRegionScoreRuleRecord(
-        eventID: eventID,
+      EventQuestionRegionScoreRuleRecord(
+        eventQuestionID: questionID,
         wineRegionTypeID: wineRegionTypeID,
         points: Int(rule.points),
         createdAt: now
@@ -1166,16 +1229,62 @@ extension API {
     }
   }
 
-  fileprivate func replaceEventRegionScoreRules(
-    _ rules: [EventRegionScoreRuleRecord],
-    eventID: UUID,
+  fileprivate func questionScoreComponentRuleRecords(
+    from rules: [Components.Schemas.CreateQuestionScoreComponentRuleRequest]?,
+    questionID: UUID
+  ) -> [EventQuestionScoreComponentRuleRecord]? {
+    let rules = rules ?? []
+    let components = rules.compactMap {
+      EventQuestionScoreComponentRuleRecord.Component(rawValue: $0.component.rawValue)
+    }
+    guard components.count == rules.count,
+      Set(components).count == components.count
+    else {
+      return nil
+    }
+    for (rule, component) in zip(rules, components) {
+      guard rule.points >= 0 else { return nil }
+      if let partialPoints = rule.partialPoints {
+        guard partialPoints >= 0, partialPoints <= rule.points else { return nil }
+      }
+      if component == .alcohol {
+        if let alcoholTolerance = rule.alcoholTolerance, alcoholTolerance < 0 {
+          return nil
+        }
+      } else if rule.alcoholTolerance != nil {
+        return nil
+      }
+    }
+    let now = Date()
+    return zip(rules, components).map { rule, component in
+      EventQuestionScoreComponentRuleRecord(
+        eventQuestionID: questionID,
+        component: component,
+        points: Int(rule.points),
+        partialPoints: rule.partialPoints.map(Int.init),
+        alcoholTolerance: rule.alcoholTolerance,
+        createdAt: now
+      )
+    }
+  }
+
+  fileprivate func replaceQuestionScoreRules(
+    regionScoreRules: [EventQuestionRegionScoreRuleRecord],
+    scoreComponentRules: [EventQuestionScoreComponentRuleRecord],
+    questionID: UUID,
     db: any Database.Connection.`Protocol`
   ) async throws {
-    let query: QueryFragment =
-      "DELETE FROM public.event_region_score_rules WHERE event_id = \(eventID, as: UUID.self)"
-    try await db.executeFragment(query)
-    if !rules.isEmpty {
-      try await EventRegionScoreRuleRecord.insert { rules }.execute(db)
+    let regionDelete: QueryFragment =
+      "DELETE FROM public.event_question_region_score_rules WHERE event_question_id = \(questionID, as: UUID.self)"
+    try await db.executeFragment(regionDelete)
+    let componentDelete: QueryFragment =
+      "DELETE FROM public.event_question_score_component_rules WHERE event_question_id = \(questionID, as: UUID.self)"
+    try await db.executeFragment(componentDelete)
+    if !regionScoreRules.isEmpty {
+      try await EventQuestionRegionScoreRuleRecord.insert { regionScoreRules }.execute(db)
+    }
+    if !scoreComponentRules.isEmpty {
+      try await EventQuestionScoreComponentRuleRecord.insert { scoreComponentRules }.execute(db)
     }
   }
 
@@ -1202,7 +1311,7 @@ extension API {
         }
         .selectStar()
         .fetchAll(db)
-      return try await snapshots(from: rows, db: db)
+      return snapshots(from: rows)
     }
   }
 
@@ -1226,7 +1335,7 @@ extension API {
           }
           .selectStar()
           .fetchAll(db)
-        return try await snapshots(from: rows, db: db)
+        return snapshots(from: rows)
       } else {
         let rows =
           try await EventRecord
@@ -1247,7 +1356,7 @@ extension API {
           }
           .selectStar()
           .fetchAll(db)
-        return try await snapshots(from: rows, db: db)
+        return snapshots(from: rows)
       }
     }
   }
@@ -1285,7 +1394,7 @@ extension API {
           .selectStar()
           .fetchAll(db)
         let eventRows = rows.map { event, _, revision in (event, revision) }
-        return try await snapshots(from: eventRows, db: db)
+        return snapshots(from: eventRows)
       } else {
         let rows =
           try await EventRecord
@@ -1317,18 +1426,18 @@ extension API {
           .selectStar()
           .fetchAll(db)
         let eventRows = rows.map { event, _, revision in (event, revision) }
-        return try await snapshots(from: eventRows, db: db)
+        return snapshots(from: eventRows)
       }
     }
   }
 
-  fileprivate func latestEventSnapshot(eventID: UUID) async throws -> EventSnapshot? {
+  func latestEventSnapshot(eventID: UUID) async throws -> EventSnapshot? {
     try await database.read { db in
       try await latestEventSnapshot(eventID: eventID, db: db)
     }
   }
 
-  fileprivate func latestEventSnapshot(
+  func latestEventSnapshot(
     eventID: UUID,
     db: any Database.Connection.`Protocol`
   ) async throws -> EventSnapshot? {
@@ -1346,31 +1455,18 @@ extension API {
       .fetchAll(db)
       .first
     guard let row else { return nil }
-    return try await snapshots(from: [row], db: db).first
+    return snapshots(from: [row]).first
   }
 
-  fileprivate func snapshots(
-    from rows: [(EventRecord, EventRevisionRecord)],
-    db: any Database.Connection.`Protocol`
-  ) async throws -> [EventSnapshot] {
-    let eventIDs = rows.map(\.0.id)
-    guard !eventIDs.isEmpty else { return [] }
-    let scoreRules =
-      try await EventRegionScoreRuleRecord
-      .where { $0.eventID.in(eventIDs) }
-      .order { ($0.eventID, $0.wineRegionTypeID) }
-      .fetchAll(db)
-    let scoreRulesByEventID = Dictionary(grouping: scoreRules, by: \.eventID)
-    return rows.map { event, revision in
-      EventSnapshot(
-        event: event,
-        revision: revision,
-        regionScoreRules: scoreRulesByEventID[event.id, default: []]
-      )
+  func snapshots(
+    from rows: [(EventRecord, EventRevisionRecord)]
+  ) -> [EventSnapshot] {
+    rows.map { event, revision in
+      EventSnapshot(event: event, revision: revision)
     }
   }
 
-  fileprivate func canViewEvent(_ event: EventSnapshot, userID: UUID) async throws -> Bool {
+  func canViewEvent(_ event: EventSnapshot, userID: UUID) async throws -> Bool {
     if event.event.organizerUserID == userID {
       return true
     }
@@ -1413,7 +1509,7 @@ extension API {
     let now = Date()
     guard event.revision.canceledAt == nil,
       now >= event.revision.startsAt,
-      now < event.revision.endsAt
+      now < event.revision.responsesDueAt
     else {
       return false
     }
@@ -1506,7 +1602,7 @@ extension API {
     }
   }
 
-  fileprivate func isEventOrganizer(
+  func isEventOrganizer(
     eventID: UUID,
     userID: UUID
   ) async throws -> Bool {
@@ -1523,14 +1619,14 @@ extension API {
     }
   }
 
-  fileprivate func eventQuestionExists(
+  func eventQuestionExists(
     questionID: UUID,
     eventID: UUID
   ) async throws -> Bool {
     try await eventQuestion(questionID: questionID, eventID: eventID) != nil
   }
 
-  fileprivate func eventQuestion(
+  func eventQuestion(
     questionID: UUID,
     eventID: UUID
   ) async throws -> EventQuestionRecord? {
@@ -1545,7 +1641,7 @@ extension API {
     }
   }
 
-  fileprivate func latestEventQuestionSnapshots(
+  func latestEventQuestionSnapshots(
     eventID: UUID
   ) async throws -> [EventQuestionSnapshot] {
     try await database.read { db in
@@ -1563,13 +1659,35 @@ extension API {
         }
         .selectStar()
         .fetchAll(db)
+      let questionIDs = rows.map(\.0.id)
+      guard !questionIDs.isEmpty else { return [] }
+      let regionScoreRules =
+        try await EventQuestionRegionScoreRuleRecord
+        .where { $0.eventQuestionID.in(questionIDs) }
+        .order { ($0.eventQuestionID, $0.wineRegionTypeID) }
+        .fetchAll(db)
+      let scoreComponentRules =
+        try await EventQuestionScoreComponentRuleRecord
+        .where { $0.eventQuestionID.in(questionIDs) }
+        .order { ($0.eventQuestionID, $0.component) }
+        .fetchAll(db)
+      let regionRulesByQuestionID = Dictionary(grouping: regionScoreRules, by: \.eventQuestionID)
+      let componentRulesByQuestionID = Dictionary(
+        grouping: scoreComponentRules,
+        by: \.eventQuestionID
+      )
       return rows.map { question, revision in
-        EventQuestionSnapshot(question: question, revision: revision)
+        EventQuestionSnapshot(
+          question: question,
+          revision: revision,
+          regionScoreRules: regionRulesByQuestionID[question.id, default: []],
+          scoreComponentRules: componentRulesByQuestionID[question.id, default: []]
+        )
       }
     }
   }
 
-  fileprivate func correctAnswer(
+  func correctAnswer(
     questionID: UUID,
     db: any Database.Connection.`Protocol`
   ) async throws -> EventQuestionCorrectAnswerRecord? {
@@ -1579,7 +1697,7 @@ extension API {
       .fetchOne(db)
   }
 
-  fileprivate func eventQuestionResponse(
+  func eventQuestionResponse(
     questionID: UUID,
     userID: UUID,
     db: any Database.Connection.`Protocol`
@@ -1593,7 +1711,7 @@ extension API {
       .fetchOne(db)
   }
 
-  fileprivate func latestCorrectAnswerRevision(
+  func latestCorrectAnswerRevision(
     answerID: UUID,
     db: any Database.Connection.`Protocol`
   ) async throws -> EventQuestionCorrectAnswerRevisionRecord? {
@@ -1604,7 +1722,7 @@ extension API {
       .fetchOne(db)
   }
 
-  fileprivate func correctAnswerVarietyIDs(
+  func correctAnswerVarietyIDs(
     revisionID: UUID,
     db: any Database.Connection.`Protocol`
   ) async throws -> [UUID] {
@@ -1615,7 +1733,7 @@ extension API {
     return rows.map(\.wineVarietyID).sorted { $0.uuidString < $1.uuidString }
   }
 
-  fileprivate func latestResponseRevision(
+  func latestResponseRevision(
     responseID: UUID,
     db: any Database.Connection.`Protocol`
   ) async throws -> EventQuestionResponseRevisionRecord? {
@@ -1626,7 +1744,7 @@ extension API {
       .fetchOne(db)
   }
 
-  fileprivate func responseVarietyIDs(
+  func responseVarietyIDs(
     revisionID: UUID,
     db: any Database.Connection.`Protocol`
   ) async throws -> [UUID] {
@@ -1640,6 +1758,8 @@ extension API {
   fileprivate func insertCorrectAnswer(
     questionID: UUID,
     regionID: UUID?,
+    producerWineRegionID: UUID?,
+    feature: String?,
     vintage: Int?,
     alcoholByVolume: Double?,
     varietyIDs: [UUID],
@@ -1674,6 +1794,8 @@ extension API {
         id: UUID(uuidString: UUID.uuidV7String())!,
         eventQuestionCorrectAnswerID: answer.id,
         wineRegionID: regionID,
+        producerWineRegionID: producerWineRegionID,
+        feature: feature,
         vintage: vintage,
         alcoholByVolume: alcoholByVolume,
         createdAt: Date()
@@ -1697,6 +1819,8 @@ extension API {
     questionID: UUID,
     userID: UUID,
     regionID: UUID?,
+    producerWineRegionID: UUID?,
+    feature: String?,
     vintage: Int?,
     alcoholByVolume: Double?,
     note: String?,
@@ -1740,6 +1864,8 @@ extension API {
         id: UUID(uuidString: UUID.uuidV7String())!,
         eventQuestionResponseID: response.id,
         wineRegionID: regionID,
+        producerWineRegionID: producerWineRegionID,
+        feature: feature,
         vintage: vintage,
         alcoholByVolume: alcoholByVolume,
         note: note,
@@ -1792,7 +1918,7 @@ extension API {
     return vintage > 0
   }
 
-  fileprivate func logEventDatabaseError(
+  func logEventDatabaseError(
     _ eventName: String,
     _ message: Logger.Message,
     userID: UUID,
@@ -1937,25 +2063,35 @@ extension Components.Schemas.Event {
       venueCoordinate: venueCoordinate,
       registrationPeriod: registrationPeriod,
       eventPeriod: eventPeriod,
-      answersPublishedAt: revision.answersPublishedAt?.timeIntervalSinceReferenceDate,
+      responsesDueAt: revision.responsesDueAt.timeIntervalSinceReferenceDate,
+      answersPublishedAt: revision.answersPublishedAt.timeIntervalSinceReferenceDate,
       capacity: revision.capacity.map(Int32.init),
       entryFee: entryFee,
       visibility: visibility,
       publishedAt: revision.publishedAt?.timeIntervalSinceReferenceDate,
       canceledAt: revision.canceledAt?.timeIntervalSinceReferenceDate,
-      regionScoreRules: snapshot.regionScoreRules.map(
-        Components.Schemas.EventRegionScoreRule.init
-      ),
       createdAt: event.createdAt.timeIntervalSinceReferenceDate
     )
   }
 }
 
-extension Components.Schemas.EventRegionScoreRule {
-  fileprivate init(_ rule: EventRegionScoreRuleRecord) {
+extension Components.Schemas.QuestionRegionScoreRule {
+  fileprivate init(_ rule: EventQuestionRegionScoreRuleRecord) {
     self.init(
       wineRegionTypeID: rule.wineRegionTypeID.uuidString,
       points: Int32(rule.points),
+      createdAt: rule.createdAt.timeIntervalSinceReferenceDate
+    )
+  }
+}
+
+extension Components.Schemas.QuestionScoreComponentRule {
+  fileprivate init(_ rule: EventQuestionScoreComponentRuleRecord) {
+    self.init(
+      component: .init(rawValue: rule.component.rawValue)!,
+      points: Int32(rule.points),
+      partialPoints: rule.partialPoints.map(Int32.init),
+      alcoholTolerance: rule.alcoholTolerance,
       createdAt: rule.createdAt.timeIntervalSinceReferenceDate
     )
   }
@@ -1984,6 +2120,12 @@ extension Components.Schemas.EventQuestion {
       imageID: revision.imageID?.uuidString,
       imageURL: imageURL,
       note: revision.note,
+      regionScoreRules: snapshot.regionScoreRules.map(
+        Components.Schemas.QuestionRegionScoreRule.init
+      ),
+      scoreComponentRules: snapshot.scoreComponentRules.map(
+        Components.Schemas.QuestionScoreComponentRule.init
+      ),
       createdAt: question.createdAt.timeIntervalSinceReferenceDate
     )
   }
@@ -1999,8 +2141,10 @@ extension Components.Schemas.EventQuestionCorrectAnswer {
       id: answer.id.uuidString,
       eventQuestionID: answer.eventQuestionID.uuidString,
       wineRegionID: revision.wineRegionID?.uuidString,
+      producerWineRegionID: revision.producerWineRegionID?.uuidString,
       vintage: revision.vintage.map(Int32.init),
       alcoholByVolume: revision.alcoholByVolume,
+      feature: revision.feature,
       wineVarietyIDs: wineVarietyIDs.map(\.uuidString),
       createdAt: answer.createdAt.timeIntervalSinceReferenceDate
     )
@@ -2018,8 +2162,10 @@ extension Components.Schemas.EventQuestionResponse {
       eventQuestionID: response.eventQuestionID.uuidString,
       userID: response.userID.uuidString,
       wineRegionID: revision.wineRegionID?.uuidString,
+      producerWineRegionID: revision.producerWineRegionID?.uuidString,
       vintage: revision.vintage.map(Int32.init),
       alcoholByVolume: revision.alcoholByVolume,
+      feature: revision.feature,
       note: revision.note,
       wineVarietyIDs: wineVarietyIDs.map(\.uuidString),
       submittedAt: response.createdAt.timeIntervalSinceReferenceDate

--- a/Sources/App/API/Events.swift
+++ b/Sources/App/API/Events.swift
@@ -1276,12 +1276,14 @@ extension API {
     questionID: UUID,
     db: any Database.Connection.`Protocol`
   ) async throws {
-    let regionDelete: QueryFragment =
-      "DELETE FROM public.event_question_region_score_rules WHERE event_question_id = \(questionID, as: UUID.self)"
-    try await db.executeFragment(regionDelete)
-    let componentDelete: QueryFragment =
-      "DELETE FROM public.event_question_score_component_rules WHERE event_question_id = \(questionID, as: UUID.self)"
-    try await db.executeFragment(componentDelete)
+    try await EventQuestionRegionScoreRuleRecord
+      .where { $0.eventQuestionID.eq(questionID) }
+      .delete()
+      .execute(db)
+    try await EventQuestionScoreComponentRuleRecord
+      .where { $0.eventQuestionID.eq(questionID) }
+      .delete()
+      .execute(db)
     if !regionScoreRules.isEmpty {
       try await EventQuestionRegionScoreRuleRecord.insert { regionScoreRules }.execute(db)
     }
@@ -1573,18 +1575,14 @@ extension API {
     eventID: UUID,
     db: any Database.Connection.`Protocol`
   ) async throws {
-    let query: QueryFragment =
-      "SELECT id FROM public.events WHERE id = \(eventID, as: UUID.self) FOR UPDATE"
-    try await db.executeFragment(query)
+    try await RowLocks.event(eventID, db: db)
   }
 
   fileprivate func lockEventQuestion(
     questionID: UUID,
     db: any Database.Connection.`Protocol`
   ) async throws {
-    let query: QueryFragment =
-      "SELECT id FROM public.event_questions WHERE id = \(questionID, as: UUID.self) FOR UPDATE"
-    try await db.executeFragment(query)
+    try await RowLocks.eventQuestion(questionID, db: db)
   }
 
   fileprivate func ownedImageExists(

--- a/Sources/App/API/Events.swift
+++ b/Sources/App/API/Events.swift
@@ -456,8 +456,8 @@ extension API {
           questionID: questionID,
           db: db
         )
+        try await RatingSettlement.invalidateQuestion(questionID: questionID, db: db)
       }
-      await invalidateQuestionRatingAfterMutation(questionID: questionID)
       return .ok(
         .init(
           body: .json(
@@ -587,7 +587,6 @@ extension API {
         varietyIDs: varietyIDs,
         requireExistingAnswer: true
       )
-      await invalidateQuestionRatingAfterMutation(questionID: questionID)
       return .ok(
         .init(
           body: .json(
@@ -1291,14 +1290,6 @@ extension API {
     }
   }
 
-  func invalidateQuestionRatingAfterMutation(questionID: UUID) async {
-    do {
-      try await invalidateQuestionRating(questionID: questionID)
-    } catch {
-      // Best-effort: score display stays live; next settle recreates ledger if invalidation failed.
-    }
-  }
-
   fileprivate func latestEventsVisible(to userID: UUID) async throws -> [EventSnapshot] {
     try await database.read { db in
       let rows =
@@ -1822,6 +1813,7 @@ extension API {
       if !answerVarieties.isEmpty {
         try await EventQuestionCorrectAnswerVarietyRecord.insert { answerVarieties }.execute(db)
       }
+      try await RatingSettlement.invalidateQuestion(questionID: questionID, db: db)
       return (answer, revision)
     }
   }

--- a/Sources/App/API/Events.swift
+++ b/Sources/App/API/Events.swift
@@ -457,6 +457,7 @@ extension API {
           db: db
         )
       }
+      await invalidateQuestionRatingAfterMutation(questionID: questionID)
       return .ok(
         .init(
           body: .json(
@@ -586,6 +587,7 @@ extension API {
         varietyIDs: varietyIDs,
         requireExistingAnswer: true
       )
+      await invalidateQuestionRatingAfterMutation(questionID: questionID)
       return .ok(
         .init(
           body: .json(
@@ -1246,6 +1248,7 @@ extension API {
       guard rule.points >= 0 else { return nil }
       if let partialPoints = rule.partialPoints {
         guard partialPoints >= 0, partialPoints <= rule.points else { return nil }
+        guard component == .alcohol || component == .producer else { return nil }
       }
       if component == .alcohol {
         if let alcoholTolerance = rule.alcoholTolerance, alcoholTolerance < 0 {
@@ -1285,6 +1288,14 @@ extension API {
     }
     if !scoreComponentRules.isEmpty {
       try await EventQuestionScoreComponentRuleRecord.insert { scoreComponentRules }.execute(db)
+    }
+  }
+
+  func invalidateQuestionRatingAfterMutation(questionID: UUID) async {
+    do {
+      try await invalidateQuestionRating(questionID: questionID)
+    } catch {
+      // Best-effort: score display stays live; next settle recreates ledger if invalidation failed.
     }
   }
 
@@ -1526,7 +1537,7 @@ extension API {
     return hasActiveParticipant
   }
 
-  fileprivate func activeParticipantExists(eventID: UUID, userID: UUID) async throws -> Bool {
+  func activeParticipantExists(eventID: UUID, userID: UUID) async throws -> Bool {
     try await database.read { db in
       let participant =
         try await EventParticipantRecord

--- a/Sources/App/API/Events.swift
+++ b/Sources/App/API/Events.swift
@@ -1837,9 +1837,7 @@ extension API {
       if requireNoExistingResponse || requireExistingResponse {
         try await lockEventQuestion(questionID: questionID, db: db)
       }
-      // The aggregate carries the stable id and first-submission time; each
-      // update only appends a new revision, mirroring the events ↔
-      // event_revisions pattern.
+      // The aggregate keeps a stable id; each update appends a revision with its own submittedAt.
       let existing = try await eventQuestionResponse(
         questionID: questionID,
         userID: userID,
@@ -2171,7 +2169,7 @@ extension Components.Schemas.EventQuestionResponse {
       feature: revision.feature,
       note: revision.note,
       wineVarietyIDs: wineVarietyIDs.map(\.uuidString),
-      submittedAt: response.createdAt.timeIntervalSinceReferenceDate
+      submittedAt: revision.submittedAt.timeIntervalSinceReferenceDate
     )
   }
 }

--- a/Sources/App/API/Ratings.swift
+++ b/Sources/App/API/Ratings.swift
@@ -150,12 +150,10 @@ extension API {
           .limit(1)
           .fetchOne(db)
         if let active {
-          let closeQuery: QueryFragment = """
-            UPDATE public.rating_seasons
-            SET ends_at = \(now, as: Date.self)
-            WHERE id = \(active.id, as: UUID.self)
-            """
-          try await db.executeFragment(closeQuery)
+          try await RatingSeasonRecord
+            .where { $0.id.eq(active.id) }
+            .update { $0.endsAt = Optional.some(now) }
+            .execute(db)
         }
         let season = RatingSeasonRecord(
           id: UUID(uuidString: UUID.uuidV7String())!,

--- a/Sources/App/API/Ratings.swift
+++ b/Sources/App/API/Ratings.swift
@@ -2,7 +2,24 @@ import Foundation
 import PostgresNIO
 import Records
 import StructuredQueriesPostgres
+import Synchronization
 import UUIDV7
+
+/// Override for tests; production always reads `ADMIN_USER_IDS` from the process environment.
+enum AdminUserIDs {
+  static let testOverride: Mutex<[UUID]?> = .init(nil)
+
+  static func contains(_ userID: UUID) -> Bool {
+    if let override = testOverride.withLock({ $0 }) {
+      return override.contains(userID)
+    }
+    let raw = ProcessInfo.processInfo.environment["ADMIN_USER_IDS"] ?? ""
+    let allowed = raw.split(separator: ",").compactMap {
+      UUID(uuidString: $0.trimmingCharacters(in: .whitespacesAndNewlines))
+    }
+    return allowed.contains(userID)
+  }
+}
 
 extension API {
   func getMyRating(
@@ -185,10 +202,6 @@ extension API {
   }
 
   func isAdminUser(_ userID: UUID) -> Bool {
-    let raw = ProcessInfo.processInfo.environment["ADMIN_USER_IDS"] ?? ""
-    let allowed = raw.split(separator: ",").compactMap {
-      UUID(uuidString: $0.trimmingCharacters(in: .whitespacesAndNewlines))
-    }
-    return allowed.contains(userID)
+    AdminUserIDs.contains(userID)
   }
 }

--- a/Sources/App/API/Ratings.swift
+++ b/Sources/App/API/Ratings.swift
@@ -2,24 +2,7 @@ import Foundation
 import PostgresNIO
 import Records
 import StructuredQueriesPostgres
-import Synchronization
 import UUIDV7
-
-/// Override for tests; production always reads `ADMIN_USER_IDS` from the process environment.
-enum AdminUserIDs {
-  static let testOverride: Mutex<[UUID]?> = .init(nil)
-
-  static func contains(_ userID: UUID) -> Bool {
-    if let override = testOverride.withLock({ $0 }) {
-      return override.contains(userID)
-    }
-    let raw = ProcessInfo.processInfo.environment["ADMIN_USER_IDS"] ?? ""
-    let allowed = raw.split(separator: ",").compactMap {
-      UUID(uuidString: $0.trimmingCharacters(in: .whitespacesAndNewlines))
-    }
-    return allowed.contains(userID)
-  }
-}
 
 extension API {
   func getMyRating(
@@ -200,6 +183,10 @@ extension API {
   }
 
   func isAdminUser(_ userID: UUID) -> Bool {
-    AdminUserIDs.contains(userID)
+    let raw = ProcessInfo.processInfo.environment["ADMIN_USER_IDS"] ?? ""
+    let allowed = raw.split(separator: ",").compactMap {
+      UUID(uuidString: $0.trimmingCharacters(in: .whitespacesAndNewlines))
+    }
+    return allowed.contains(userID)
   }
 }

--- a/Sources/App/API/Ratings.swift
+++ b/Sources/App/API/Ratings.swift
@@ -12,7 +12,7 @@ extension API {
 
     do {
       guard let season = try await activeRatingSeason() else {
-        return .badRequest
+        return .notFound
       }
       let rating =
         try await database.read { db in
@@ -95,17 +95,12 @@ extension API {
           .fetchAll(db)
       }
 
-      var entries: [Components.Schemas.RatingLeaderboardEntry] = []
-      var rank: Int32 = 1
-      for row in rows {
-        entries.append(
-          .init(
-            rank: rank,
-            userID: row.userID.uuidString,
-            rating: Int32(row.rating)
-          )
+      let entries = Ranking.competitionRanks(rows) { $0.rating }.map { rank, row in
+        Components.Schemas.RatingLeaderboardEntry(
+          rank: rank,
+          userID: row.userID.uuidString,
+          rating: Int32(row.rating)
         )
-        rank += 1
       }
       return .ok(.init(body: .json(entries)))
     } catch {
@@ -126,7 +121,7 @@ extension API {
     guard case .json(let body) = input.body else { return .badRequest }
     let name = body.name.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !name.isEmpty else { return .badRequest }
-    guard isAdminUser(userID) else { return .unauthorized }
+    guard isAdminUser(userID) else { return .forbidden }
 
     do {
       let now = Date()

--- a/Sources/App/API/Ratings.swift
+++ b/Sources/App/API/Ratings.swift
@@ -1,0 +1,198 @@
+import Foundation
+import PostgresNIO
+import Records
+import StructuredQueriesPostgres
+import UUIDV7
+
+extension API {
+  func getMyRating(
+    _ input: Operations.GetMyRating.Input
+  ) async throws -> Operations.GetMyRating.Output {
+    guard let userID = UserTokenContext.currentUserID else { return .unauthorized }
+
+    do {
+      guard let season = try await activeRatingSeason() else {
+        return .badRequest
+      }
+      let rating =
+        try await database.read { db in
+          try await UserSeasonRatingRecord
+            .where {
+              $0.userID.eq(userID)
+                .and($0.seasonID.eq(season.id))
+            }
+            .limit(1)
+            .fetchOne(db)
+        }?.rating ?? RatingSettlement.initialRating
+
+      let ledger =
+        try await database.read { db in
+          try await UserRatingLedgerRecord
+            .where {
+              $0.userID.eq(userID)
+                .and($0.seasonID.eq(season.id))
+            }
+            .order { ($0.createdAt.desc(), $0.id.desc()) }
+            .limit(50)
+            .fetchAll(db)
+        }
+
+      return .ok(
+        .init(
+          body: .json(
+            Components.Schemas.UserRating(
+              seasonID: season.id.uuidString,
+              seasonName: season.name,
+              rating: Int32(rating),
+              recentLedger: ledger.map { entry in
+                Components.Schemas.RatingLedgerEntry(
+                  id: entry.id.uuidString,
+                  eventQuestionID: entry.eventQuestionID.uuidString,
+                  performance: entry.performance,
+                  fieldAverage: entry.fieldAverage,
+                  delta: Int32(entry.delta),
+                  ratingAfter: Int32(entry.ratingAfter),
+                  createdAt: entry.createdAt.timeIntervalSinceReferenceDate
+                )
+              }
+            )
+          )
+        )
+      )
+    } catch {
+      logEventDatabaseError(
+        "rating.me_failed",
+        "Failed to fetch user rating",
+        userID: userID,
+        error: error
+      )
+      return .badRequest
+    }
+  }
+
+  func getRatingLeaderboard(
+    _ input: Operations.GetRatingLeaderboard.Input
+  ) async throws -> Operations.GetRatingLeaderboard.Output {
+    guard let userID = UserTokenContext.currentUserID else { return .unauthorized }
+
+    do {
+      let season: RatingSeasonRecord?
+      if let seasonIDString = input.query.seasonId {
+        guard let seasonID = UUID(uuidString: seasonIDString) else { return .badRequest }
+        season = try await database.read { db in
+          try await RatingSeasonRecord.where { $0.id.eq(seasonID) }.limit(1).fetchOne(db)
+        }
+      } else {
+        season = try await activeRatingSeason()
+      }
+      guard let season else { return .notFound }
+
+      let rows = try await database.read { db in
+        try await UserSeasonRatingRecord
+          .where { $0.seasonID.eq(season.id) }
+          .order { ($0.rating.desc(), $0.userID) }
+          .limit(100)
+          .fetchAll(db)
+      }
+
+      var entries: [Components.Schemas.RatingLeaderboardEntry] = []
+      var rank: Int32 = 1
+      for row in rows {
+        entries.append(
+          .init(
+            rank: rank,
+            userID: row.userID.uuidString,
+            rating: Int32(row.rating)
+          )
+        )
+        rank += 1
+      }
+      return .ok(.init(body: .json(entries)))
+    } catch {
+      logEventDatabaseError(
+        "rating.leaderboard_failed",
+        "Failed to fetch rating leaderboard",
+        userID: userID,
+        error: error
+      )
+      return .badRequest
+    }
+  }
+
+  func createRatingSeason(
+    _ input: Operations.CreateRatingSeason.Input
+  ) async throws -> Operations.CreateRatingSeason.Output {
+    guard let userID = UserTokenContext.currentUserID else { return .unauthorized }
+    guard case .json(let body) = input.body else { return .badRequest }
+    let name = body.name.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !name.isEmpty else { return .badRequest }
+    guard isAdminUser(userID) else { return .unauthorized }
+
+    do {
+      let now = Date()
+      let season = try await database.withTransaction { db -> RatingSeasonRecord in
+        let active = try await RatingSeasonRecord
+          .where { $0.endsAt.is(nil) }
+          .order { ($0.startsAt.desc(), $0.id.desc()) }
+          .limit(1)
+          .fetchOne(db)
+        if let active {
+          let closeQuery: QueryFragment = """
+            UPDATE public.rating_seasons
+            SET ends_at = \(now, as: Date.self)
+            WHERE id = \(active.id, as: UUID.self)
+            """
+          try await db.executeFragment(closeQuery)
+        }
+        let season = RatingSeasonRecord(
+          id: UUID(uuidString: UUID.uuidV7String())!,
+          name: name,
+          startsAt: now,
+          endsAt: nil,
+          createdAt: now
+        )
+        try await RatingSeasonRecord.insert { season }.execute(db)
+        return season
+      }
+      return .ok(
+        .init(
+          body: .json(
+            Components.Schemas.RatingSeason(
+              id: season.id.uuidString,
+              name: season.name,
+              startsAt: season.startsAt.timeIntervalSinceReferenceDate,
+              endsAt: season.endsAt?.timeIntervalSinceReferenceDate,
+              createdAt: season.createdAt.timeIntervalSinceReferenceDate
+            )
+          )
+        )
+      )
+    } catch {
+      logEventDatabaseError(
+        "rating.season_create_failed",
+        "Failed to create rating season",
+        userID: userID,
+        error: error
+      )
+      return .badRequest
+    }
+  }
+
+  func activeRatingSeason() async throws -> RatingSeasonRecord? {
+    try await database.read { db in
+      try await RatingSeasonRecord
+        .where { $0.endsAt.is(nil) }
+        .order { ($0.startsAt.desc(), $0.id.desc()) }
+        .limit(1)
+        .fetchOne(db)
+    }
+  }
+
+  func isAdminUser(_ userID: UUID) -> Bool {
+    let raw = ProcessInfo.processInfo.environment["ADMIN_USER_IDS"] ?? ""
+    let allowed = raw.split(separator: ",").compactMap {
+      UUID(uuidString: $0.trimmingCharacters(in: .whitespacesAndNewlines))
+    }
+    return allowed.contains(userID)
+  }
+}

--- a/Sources/App/API/Ratings.swift
+++ b/Sources/App/API/Ratings.swift
@@ -131,7 +131,8 @@ extension API {
     do {
       let now = Date()
       let season = try await database.withTransaction { db -> RatingSeasonRecord in
-        let active = try await RatingSeasonRecord
+        let active =
+          try await RatingSeasonRecord
           .where { $0.endsAt.is(nil) }
           .order { ($0.startsAt.desc(), $0.id.desc()) }
           .limit(1)

--- a/Sources/App/Model/EventRecords.swift
+++ b/Sources/App/Model/EventRecords.swift
@@ -35,7 +35,8 @@ struct EventRevisionRecord: Codable, Identifiable, Hashable {
   @Column("registration_ends_at") var registrationEndsAt: Date?
   @Column("starts_at") var startsAt: Date
   @Column("ends_at") var endsAt: Date
-  @Column("answers_published_at") var answersPublishedAt: Date?
+  @Column("responses_due_at") var responsesDueAt: Date
+  @Column("answers_published_at") var answersPublishedAt: Date
   var capacity: Int?
   @Column("entry_fee_minor_amount") var entryFeeMinorAmount: Int64?
   @Column("entry_fee_currency_code") var entryFeeCurrencyCode: String?
@@ -78,11 +79,29 @@ struct EventQuestionRevisionRecord: Codable, Identifiable, Hashable {
   @Column("created_at") var createdAt: Date
 }
 
-@Table("event_region_score_rules")
-struct EventRegionScoreRuleRecord: Codable, Hashable {
-  @Column("event_id") var eventID: UUID
+@Table("event_question_region_score_rules")
+struct EventQuestionRegionScoreRuleRecord: Codable, Hashable {
+  @Column("event_question_id") var eventQuestionID: UUID
   @Column("wine_region_type_id") var wineRegionTypeID: UUID
   var points: Int
+  @Column("created_at") var createdAt: Date
+}
+
+@Table("event_question_score_component_rules")
+struct EventQuestionScoreComponentRuleRecord: Codable, Hashable {
+  enum Component: String, Codable, QueryBindable, Sendable {
+    case variety
+    case vintage
+    case alcohol
+    case producer
+    case feature
+  }
+
+  @Column("event_question_id") var eventQuestionID: UUID
+  var component: Component
+  var points: Int
+  @Column("partial_points") var partialPoints: Int?
+  @Column("alcohol_tolerance") var alcoholTolerance: Double?
   @Column("created_at") var createdAt: Date
 }
 
@@ -137,6 +156,8 @@ struct EventQuestionCorrectAnswerRevisionRecord: Codable, Identifiable, Hashable
   var id: UUID
   @Column("event_question_correct_answer_id") var eventQuestionCorrectAnswerID: UUID
   @Column("wine_region_id") var wineRegionID: UUID?
+  @Column("producer_wine_region_id") var producerWineRegionID: UUID?
+  var feature: String?
   var vintage: Int?
   @Column("alcohol_by_volume") var alcoholByVolume: Double?
   @Column("created_at") var createdAt: Date
@@ -163,6 +184,8 @@ struct EventQuestionResponseRevisionRecord: Codable, Identifiable, Hashable {
   var id: UUID
   @Column("event_question_response_id") var eventQuestionResponseID: UUID
   @Column("wine_region_id") var wineRegionID: UUID?
+  @Column("producer_wine_region_id") var producerWineRegionID: UUID?
+  var feature: String?
   var vintage: Int?
   @Column("alcohol_by_volume") var alcoholByVolume: Double?
   var note: String?
@@ -173,5 +196,35 @@ struct EventQuestionResponseRevisionRecord: Codable, Identifiable, Hashable {
 struct EventQuestionResponseVarietyRecord: Codable, Hashable {
   @Column("event_question_response_revision_id") var eventQuestionResponseRevisionID: UUID
   @Column("wine_variety_id") var wineVarietyID: UUID
+  @Column("created_at") var createdAt: Date
+}
+
+@Table("rating_seasons")
+struct RatingSeasonRecord: Codable, Identifiable, Hashable {
+  var id: UUID
+  var name: String
+  @Column("starts_at") var startsAt: Date
+  @Column("ends_at") var endsAt: Date?
+  @Column("created_at") var createdAt: Date
+}
+
+@Table("user_season_ratings")
+struct UserSeasonRatingRecord: Codable, Hashable {
+  @Column("user_id") var userID: UUID
+  @Column("season_id") var seasonID: UUID
+  var rating: Int
+  @Column("updated_at") var updatedAt: Date
+}
+
+@Table("user_rating_ledger")
+struct UserRatingLedgerRecord: Codable, Identifiable, Hashable {
+  var id: UUID
+  @Column("user_id") var userID: UUID
+  @Column("season_id") var seasonID: UUID
+  @Column("event_question_id") var eventQuestionID: UUID
+  var performance: Double
+  @Column("field_average") var fieldAverage: Double
+  var delta: Int
+  @Column("rating_after") var ratingAfter: Int
   @Column("created_at") var createdAt: Date
 }

--- a/Sources/App/Model/RowLocks.swift
+++ b/Sources/App/Model/RowLocks.swift
@@ -1,0 +1,25 @@
+import Foundation
+import PostgresNIO
+import Records
+import StructuredQueriesPostgres
+
+/// Row-level locks used inside transactions. The ORM does not yet expose `FOR UPDATE`.
+enum RowLocks {
+  static func event(
+    _ eventID: UUID,
+    db: any Database.Connection.`Protocol`
+  ) async throws {
+    let query: QueryFragment =
+      "SELECT id FROM public.events WHERE id = \(eventID, as: UUID.self) FOR UPDATE"
+    try await db.executeFragment(query)
+  }
+
+  static func eventQuestion(
+    _ questionID: UUID,
+    db: any Database.Connection.`Protocol`
+  ) async throws {
+    let query: QueryFragment =
+      "SELECT id FROM public.event_questions WHERE id = \(questionID, as: UUID.self) FOR UPDATE"
+    try await db.executeFragment(query)
+  }
+}

--- a/Sources/App/Scoring/QuestionScorer.swift
+++ b/Sources/App/Scoring/QuestionScorer.swift
@@ -164,8 +164,8 @@ enum QuestionScorer {
   }
 
   /// Full points for matching producer IDs.
-  /// Partial points when the correct producer is known and the response is blank (anonymous),
-  /// or — only when there is no separate feature rule — when features match.
+  /// Partial points only when there is no separate feature rule and features match.
+  /// A blank producer response scores zero (no anonymous partial credit).
   private static func producerPoints(
     correct: ScoringAnswerPayload,
     response: ScoringAnswerPayload,
@@ -177,54 +177,12 @@ enum QuestionScorer {
     if response.producerWineRegionID == correctProducer {
       return points
     }
-    guard let partialPoints else { return 0 }
-    if response.producerWineRegionID == nil {
+    guard let partialPoints, allowFeaturePartial else { return 0 }
+    let correctFeature = normalizeFeature(correct.feature)
+    let responseFeature = normalizeFeature(response.feature)
+    if correctFeature != nil, correctFeature == responseFeature {
       return partialPoints
     }
-    if allowFeaturePartial {
-      let correctFeature = normalizeFeature(correct.feature)
-      let responseFeature = normalizeFeature(response.feature)
-      if correctFeature != nil, correctFeature == responseFeature {
-        return partialPoints
-      }
-    }
     return 0
-  }
-}
-
-enum RatingCalculator {
-  static let kFactor = 32
-  static let maxAbsDelta = 50
-
-  static func delta(performance: Double, fieldAverage: Double) -> Int {
-    let raw = Double(kFactor) * (performance - fieldAverage)
-    let rounded = Int(raw.rounded())
-    return min(maxAbsDelta, max(-maxAbsDelta, rounded))
-  }
-}
-
-enum Ranking {
-  /// Competition ranking: equal scores share the same rank (1, 2, 2, 4).
-  static func competitionRanks<T>(
-    _ rows: [T],
-    score: (T) -> Int
-  ) -> [(rank: Int32, row: T)] {
-    guard !rows.isEmpty else { return [] }
-    var result: [(rank: Int32, row: T)] = []
-    var index = 0
-    var currentRank: Int32 = 1
-    var previousScore: Int?
-    for row in rows {
-      let value = score(row)
-      if let previousScore, value != previousScore {
-        currentRank = Int32(index + 1)
-      } else if previousScore == nil {
-        currentRank = 1
-      }
-      result.append((currentRank, row))
-      previousScore = value
-      index += 1
-    }
-    return result
   }
 }

--- a/Sources/App/Scoring/QuestionScorer.swift
+++ b/Sources/App/Scoring/QuestionScorer.swift
@@ -1,0 +1,195 @@
+import Foundation
+
+enum ScoreComponentKind: String, Sendable, Hashable {
+  case region
+  case variety
+  case vintage
+  case alcohol
+  case producer
+  case feature
+}
+
+struct ScoreComponentResult: Sendable, Hashable {
+  var component: ScoreComponentKind
+  var earnedPoints: Int
+  var maxPoints: Int
+}
+
+struct QuestionScoreResult: Sendable, Hashable {
+  var components: [ScoreComponentResult]
+  var earnedPoints: Int
+  var maxPoints: Int
+
+  var performance: Double {
+    guard maxPoints > 0 else { return 0 }
+    return Double(earnedPoints) / Double(maxPoints)
+  }
+}
+
+struct ScoringAnswerPayload: Sendable, Hashable {
+  var wineRegionID: UUID?
+  var producerWineRegionID: UUID?
+  var feature: String?
+  var vintage: Int?
+  var alcoholByVolume: Double?
+  var wineVarietyIDs: Set<UUID>
+}
+
+struct RegionAncestor: Sendable, Hashable {
+  var id: UUID
+  var wineRegionTypeID: UUID
+}
+
+enum QuestionScorer {
+  static func normalizeFeature(_ value: String?) -> String? {
+    guard let value else { return nil }
+    let normalized = value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    return normalized.isEmpty ? nil : normalized
+  }
+
+  static func score(
+    correct: ScoringAnswerPayload,
+    response: ScoringAnswerPayload,
+    regionRules: [EventQuestionRegionScoreRuleRecord],
+    componentRules: [EventQuestionScoreComponentRuleRecord],
+    correctRegionAncestors: [RegionAncestor],
+    responseRegionAncestors: [RegionAncestor]
+  ) -> QuestionScoreResult {
+    var components: [ScoreComponentResult] = []
+
+    if !regionRules.isEmpty {
+      let maxPoints = regionRules.map(\.points).max() ?? 0
+      let pointsByType = Dictionary(
+        regionRules.map { ($0.wineRegionTypeID, $0.points) },
+        uniquingKeysWith: { current, _ in current }
+      )
+      let responseIDs = Set(responseRegionAncestors.map(\.id))
+      var earned = 0
+      for ancestor in correctRegionAncestors where responseIDs.contains(ancestor.id) {
+        if let points = pointsByType[ancestor.wineRegionTypeID] {
+          earned = max(earned, points)
+        }
+      }
+      components.append(
+        ScoreComponentResult(component: .region, earnedPoints: earned, maxPoints: maxPoints)
+      )
+    }
+
+    for rule in componentRules {
+      let result: ScoreComponentResult
+      switch rule.component {
+      case .variety:
+        let earned = correct.wineVarietyIDs == response.wineVarietyIDs ? rule.points : 0
+        result = ScoreComponentResult(
+          component: .variety,
+          earnedPoints: earned,
+          maxPoints: rule.points
+        )
+      case .vintage:
+        let earned =
+          correct.vintage != nil && correct.vintage == response.vintage ? rule.points : 0
+        result = ScoreComponentResult(
+          component: .vintage,
+          earnedPoints: earned,
+          maxPoints: rule.points
+        )
+      case .alcohol:
+        let earned = alcoholPoints(
+          correct: correct.alcoholByVolume,
+          response: response.alcoholByVolume,
+          points: rule.points,
+          partialPoints: rule.partialPoints,
+          tolerance: rule.alcoholTolerance
+        )
+        result = ScoreComponentResult(
+          component: .alcohol,
+          earnedPoints: earned,
+          maxPoints: rule.points
+        )
+      case .producer:
+        let earned = producerPoints(
+          correct: correct,
+          response: response,
+          points: rule.points,
+          partialPoints: rule.partialPoints
+        )
+        result = ScoreComponentResult(
+          component: .producer,
+          earnedPoints: earned,
+          maxPoints: rule.points
+        )
+      case .feature:
+        let correctFeature = normalizeFeature(correct.feature)
+        let responseFeature = normalizeFeature(response.feature)
+        let earned =
+          correctFeature != nil && correctFeature == responseFeature ? rule.points : 0
+        result = ScoreComponentResult(
+          component: .feature,
+          earnedPoints: earned,
+          maxPoints: rule.points
+        )
+      }
+      components.append(result)
+    }
+
+    let earnedPoints = components.reduce(0) { $0 + $1.earnedPoints }
+    let maxPoints = components.reduce(0) { $0 + $1.maxPoints }
+    return QuestionScoreResult(
+      components: components,
+      earnedPoints: earnedPoints,
+      maxPoints: maxPoints
+    )
+  }
+
+  private static func alcoholPoints(
+    correct: Double?,
+    response: Double?,
+    points: Int,
+    partialPoints: Int?,
+    tolerance: Double?
+  ) -> Int {
+    guard let correct, let response else { return 0 }
+    let delta = abs(correct - response)
+    if delta == 0 { return points }
+    if let tolerance, delta <= tolerance {
+      return partialPoints ?? 0
+    }
+    return 0
+  }
+
+  private static func producerPoints(
+    correct: ScoringAnswerPayload,
+    response: ScoringAnswerPayload,
+    points: Int,
+    partialPoints: Int?
+  ) -> Int {
+    if let correctProducer = correct.producerWineRegionID,
+      correctProducer == response.producerWineRegionID
+    {
+      return points
+    }
+    guard let partialPoints else { return 0 }
+    let correctFeature = normalizeFeature(correct.feature)
+    let responseFeature = normalizeFeature(response.feature)
+    if correctFeature != nil, correctFeature == responseFeature {
+      return partialPoints
+    }
+    if correct.producerWineRegionID == nil, response.producerWineRegionID == nil,
+      correctFeature == nil, responseFeature == nil
+    {
+      return partialPoints
+    }
+    return 0
+  }
+}
+
+enum RatingCalculator {
+  static let kFactor = 32
+  static let maxAbsDelta = 50
+
+  static func delta(performance: Double, fieldAverage: Double) -> Int {
+    let raw = Double(kFactor) * (performance - fieldAverage)
+    let rounded = Int(raw.rounded())
+    return min(maxAbsDelta, max(-maxAbsDelta, rounded))
+  }
+}

--- a/Sources/App/Scoring/QuestionScorer.swift
+++ b/Sources/App/Scoring/QuestionScorer.swift
@@ -41,6 +41,8 @@ struct RegionAncestor: Sendable, Hashable {
 }
 
 enum QuestionScorer {
+  static let alcoholExactEpsilon = 1e-9
+
   static func normalizeFeature(_ value: String?) -> String? {
     guard let value else { return nil }
     let normalized = value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
@@ -56,6 +58,7 @@ enum QuestionScorer {
     responseRegionAncestors: [RegionAncestor]
   ) -> QuestionScoreResult {
     var components: [ScoreComponentResult] = []
+    let hasFeatureRule = componentRules.contains { $0.component == .feature }
 
     if !regionRules.isEmpty {
       let maxPoints = regionRules.map(\.points).max() ?? 0
@@ -79,7 +82,9 @@ enum QuestionScorer {
       let result: ScoreComponentResult
       switch rule.component {
       case .variety:
-        let earned = correct.wineVarietyIDs == response.wineVarietyIDs ? rule.points : 0
+        let earned =
+          !correct.wineVarietyIDs.isEmpty
+            && correct.wineVarietyIDs == response.wineVarietyIDs ? rule.points : 0
         result = ScoreComponentResult(
           component: .variety,
           earnedPoints: earned,
@@ -111,7 +116,8 @@ enum QuestionScorer {
           correct: correct,
           response: response,
           points: rule.points,
-          partialPoints: rule.partialPoints
+          partialPoints: rule.partialPoints,
+          allowFeaturePartial: !hasFeatureRule
         )
         result = ScoreComponentResult(
           component: .producer,
@@ -150,34 +156,37 @@ enum QuestionScorer {
   ) -> Int {
     guard let correct, let response else { return 0 }
     let delta = abs(correct - response)
-    if delta == 0 { return points }
+    if delta <= alcoholExactEpsilon { return points }
     if let tolerance, delta <= tolerance {
       return partialPoints ?? 0
     }
     return 0
   }
 
+  /// Full points for matching producer IDs.
+  /// Partial points when the correct producer is known and the response is blank (anonymous),
+  /// or — only when there is no separate feature rule — when features match.
   private static func producerPoints(
     correct: ScoringAnswerPayload,
     response: ScoringAnswerPayload,
     points: Int,
-    partialPoints: Int?
+    partialPoints: Int?,
+    allowFeaturePartial: Bool
   ) -> Int {
-    if let correctProducer = correct.producerWineRegionID,
-      correctProducer == response.producerWineRegionID
-    {
+    guard let correctProducer = correct.producerWineRegionID else { return 0 }
+    if response.producerWineRegionID == correctProducer {
       return points
     }
     guard let partialPoints else { return 0 }
-    let correctFeature = normalizeFeature(correct.feature)
-    let responseFeature = normalizeFeature(response.feature)
-    if correctFeature != nil, correctFeature == responseFeature {
+    if response.producerWineRegionID == nil {
       return partialPoints
     }
-    if correct.producerWineRegionID == nil, response.producerWineRegionID == nil,
-      correctFeature == nil, responseFeature == nil
-    {
-      return partialPoints
+    if allowFeaturePartial {
+      let correctFeature = normalizeFeature(correct.feature)
+      let responseFeature = normalizeFeature(response.feature)
+      if correctFeature != nil, correctFeature == responseFeature {
+        return partialPoints
+      }
     }
     return 0
   }
@@ -191,5 +200,31 @@ enum RatingCalculator {
     let raw = Double(kFactor) * (performance - fieldAverage)
     let rounded = Int(raw.rounded())
     return min(maxAbsDelta, max(-maxAbsDelta, rounded))
+  }
+}
+
+enum Ranking {
+  /// Competition ranking: equal scores share the same rank (1, 2, 2, 4).
+  static func competitionRanks<T>(
+    _ rows: [T],
+    score: (T) -> Int
+  ) -> [(rank: Int32, row: T)] {
+    guard !rows.isEmpty else { return [] }
+    var result: [(rank: Int32, row: T)] = []
+    var index = 0
+    var currentRank: Int32 = 1
+    var previousScore: Int?
+    for row in rows {
+      let value = score(row)
+      if let previousScore, value != previousScore {
+        currentRank = Int32(index + 1)
+      } else if previousScore == nil {
+        currentRank = 1
+      }
+      result.append((currentRank, row))
+      previousScore = value
+      index += 1
+    }
+    return result
   }
 }

--- a/Sources/App/Scoring/Ranking.swift
+++ b/Sources/App/Scoring/Ranking.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+enum Ranking {
+  /// Competition ranking: equal scores share the same rank (1, 2, 2, 4).
+  static func competitionRanks<T>(
+    _ rows: [T],
+    score: (T) -> Int
+  ) -> [(rank: Int32, row: T)] {
+    guard !rows.isEmpty else { return [] }
+    var result: [(rank: Int32, row: T)] = []
+    var index = 0
+    var currentRank: Int32 = 1
+    var previousScore: Int?
+    for row in rows {
+      let value = score(row)
+      if let previousScore, value != previousScore {
+        currentRank = Int32(index + 1)
+      } else if previousScore == nil {
+        currentRank = 1
+      }
+      result.append((currentRank, row))
+      previousScore = value
+      index += 1
+    }
+    return result
+  }
+}

--- a/Sources/App/Scoring/RatingCalculator.swift
+++ b/Sources/App/Scoring/RatingCalculator.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+enum RatingCalculator {
+  static let kFactor = 32
+  static let maxAbsDelta = 50
+
+  static func delta(performance: Double, fieldAverage: Double) -> Int {
+    let raw = Double(kFactor) * (performance - fieldAverage)
+    let rounded = Int(raw.rounded())
+    return min(maxAbsDelta, max(-maxAbsDelta, rounded))
+  }
+}

--- a/Sources/App/Scoring/RatingSettlement.swift
+++ b/Sources/App/Scoring/RatingSettlement.swift
@@ -14,9 +14,7 @@ enum RatingSettlement {
     database: PostgresClient
   ) async throws {
     try await database.withTransaction { db in
-      let lockEvent: QueryFragment =
-        "SELECT id FROM public.events WHERE id = \(eventID, as: UUID.self) FOR UPDATE"
-      try await db.executeFragment(lockEvent)
+      try await RowLocks.event(eventID, db: db)
 
       guard
         let season = try await seasonForSettlement(at: answersPublishedAt, db: db)
@@ -31,9 +29,7 @@ enum RatingSettlement {
         .fetchAll(db)
 
       for question in questions {
-        let lockQuestion: QueryFragment =
-          "SELECT id FROM public.event_questions WHERE id = \(question.id, as: UUID.self) FOR UPDATE"
-        try await db.executeFragment(lockQuestion)
+        try await RowLocks.eventQuestion(question.id, db: db)
 
         let existing =
           try await UserRatingLedgerRecord
@@ -58,29 +54,13 @@ enum RatingSettlement {
             fieldAverage: average
           )
           let now = Date()
-          let upsert: QueryFragment = """
-            INSERT INTO public.user_season_ratings (user_id, season_id, rating, updated_at)
-            VALUES (
-              \(userID, as: UUID.self),
-              \(season.id, as: UUID.self),
-              \(initialRating + delta, as: Int.self),
-              \(now, as: Date.self)
-            )
-            ON CONFLICT (user_id, season_id) DO UPDATE
-            SET rating = public.user_season_ratings.rating + \(delta, as: Int.self),
-                updated_at = EXCLUDED.updated_at
-            """
-          try await db.executeFragment(upsert)
-
-          let ratingAfter =
-            try await UserSeasonRatingRecord
-            .where {
-              $0.userID.eq(userID)
-                .and($0.seasonID.eq(season.id))
-            }
-            .limit(1)
-            .fetchOne(db)?
-            .rating ?? (initialRating + delta)
+          let ratingAfter = try await applyRatingDelta(
+            userID: userID,
+            seasonID: season.id,
+            delta: delta,
+            now: now,
+            db: db
+          )
 
           try await UserRatingLedgerRecord.insert {
             UserRatingLedgerRecord(
@@ -114,9 +94,7 @@ enum RatingSettlement {
     questionID: UUID,
     db: any Database.Connection.`Protocol`
   ) async throws {
-    let lockQuestion: QueryFragment =
-      "SELECT id FROM public.event_questions WHERE id = \(questionID, as: UUID.self) FOR UPDATE"
-    try await db.executeFragment(lockQuestion)
+    try await RowLocks.eventQuestion(questionID, db: db)
 
     let entries =
       try await UserRatingLedgerRecord
@@ -124,18 +102,30 @@ enum RatingSettlement {
       .fetchAll(db)
     let now = Date()
     for entry in entries {
-      let reverse: QueryFragment = """
-        UPDATE public.user_season_ratings
-        SET rating = rating - \(entry.delta, as: Int.self),
-            updated_at = \(now, as: Date.self)
-        WHERE user_id = \(entry.userID, as: UUID.self)
-          AND season_id = \(entry.seasonID, as: UUID.self)
-        """
-      try await db.executeFragment(reverse)
+      let existing =
+        try await UserSeasonRatingRecord
+        .where {
+          $0.userID.eq(entry.userID)
+            .and($0.seasonID.eq(entry.seasonID))
+        }
+        .limit(1)
+        .fetchOne(db)
+      guard let existing else { continue }
+      try await UserSeasonRatingRecord
+        .where {
+          $0.userID.eq(entry.userID)
+            .and($0.seasonID.eq(entry.seasonID))
+        }
+        .update {
+          $0.rating = existing.rating - entry.delta
+          $0.updatedAt = now
+        }
+        .execute(db)
     }
-    let deleteLedger: QueryFragment =
-      "DELETE FROM public.user_rating_ledger WHERE event_question_id = \(questionID, as: UUID.self)"
-    try await db.executeFragment(deleteLedger)
+    try await UserRatingLedgerRecord
+      .where { $0.eventQuestionID.eq(questionID) }
+      .delete()
+      .execute(db)
   }
 
   static func seasonForSettlement(
@@ -153,5 +143,49 @@ enum RatingSettlement {
       }
       return true
     }
+  }
+
+  /// Applies `delta` to the user's season rating and returns the rating after the change.
+  private static func applyRatingDelta(
+    userID: UUID,
+    seasonID: UUID,
+    delta: Int,
+    now: Date,
+    db: any Database.Connection.`Protocol`
+  ) async throws -> Int {
+    let existing =
+      try await UserSeasonRatingRecord
+      .where {
+        $0.userID.eq(userID)
+          .and($0.seasonID.eq(seasonID))
+      }
+      .limit(1)
+      .fetchOne(db)
+
+    if let existing {
+      let ratingAfter = existing.rating + delta
+      try await UserSeasonRatingRecord
+        .where {
+          $0.userID.eq(userID)
+            .and($0.seasonID.eq(seasonID))
+        }
+        .update {
+          $0.rating = ratingAfter
+          $0.updatedAt = now
+        }
+        .execute(db)
+      return ratingAfter
+    }
+
+    let ratingAfter = initialRating + delta
+    try await UserSeasonRatingRecord.insert {
+      UserSeasonRatingRecord(
+        userID: userID,
+        seasonID: seasonID,
+        rating: ratingAfter,
+        updatedAt: now
+      )
+    }.execute(db)
+    return ratingAfter
   }
 }

--- a/Sources/App/Scoring/RatingSettlement.swift
+++ b/Sources/App/Scoring/RatingSettlement.swift
@@ -1,0 +1,157 @@
+import Foundation
+import PostgresNIO
+import Records
+import StructuredQueriesPostgres
+import UUIDV7
+
+enum RatingSettlement {
+  static let initialRating = 1000
+
+  static func settle(
+    eventID: UUID,
+    organizerUserID: UUID,
+    answersPublishedAt: Date,
+    database: PostgresClient
+  ) async throws {
+    try await database.withTransaction { db in
+      let lockEvent: QueryFragment =
+        "SELECT id FROM public.events WHERE id = \(eventID, as: UUID.self) FOR UPDATE"
+      try await db.executeFragment(lockEvent)
+
+      guard
+        let season = try await seasonForSettlement(at: answersPublishedAt, db: db)
+      else {
+        return
+      }
+
+      let questions =
+        try await EventQuestionRecord
+        .where { $0.eventID.eq(eventID) }
+        .order { $0.questionNumber }
+        .fetchAll(db)
+
+      for question in questions {
+        let lockQuestion: QueryFragment =
+          "SELECT id FROM public.event_questions WHERE id = \(question.id, as: UUID.self) FOR UPDATE"
+        try await db.executeFragment(lockQuestion)
+
+        let existing =
+          try await UserRatingLedgerRecord
+          .where {
+            $0.seasonID.eq(season.id)
+              .and($0.eventQuestionID.eq(question.id))
+          }
+          .limit(1)
+          .fetchOne(db)
+        if existing != nil { continue }
+
+        let scores =
+          try await API.scoreQuestion(questionID: question.id, db: db)
+          .filter { $0.0 != organizerUserID }
+        guard !scores.isEmpty else { continue }
+        let average =
+          scores.map(\.1.performance).reduce(0, +) / Double(scores.count)
+
+        for (userID, result) in scores {
+          let delta = RatingCalculator.delta(
+            performance: result.performance,
+            fieldAverage: average
+          )
+          let now = Date()
+          let upsert: QueryFragment = """
+            INSERT INTO public.user_season_ratings (user_id, season_id, rating, updated_at)
+            VALUES (
+              \(userID, as: UUID.self),
+              \(season.id, as: UUID.self),
+              \(initialRating + delta, as: Int.self),
+              \(now, as: Date.self)
+            )
+            ON CONFLICT (user_id, season_id) DO UPDATE
+            SET rating = public.user_season_ratings.rating + \(delta, as: Int.self),
+                updated_at = EXCLUDED.updated_at
+            """
+          try await db.executeFragment(upsert)
+
+          let ratingAfter =
+            try await UserSeasonRatingRecord
+            .where {
+              $0.userID.eq(userID)
+                .and($0.seasonID.eq(season.id))
+            }
+            .limit(1)
+            .fetchOne(db)?
+            .rating ?? (initialRating + delta)
+
+          try await UserRatingLedgerRecord.insert {
+            UserRatingLedgerRecord(
+              id: UUID(uuidString: UUID.uuidV7String())!,
+              userID: userID,
+              seasonID: season.id,
+              eventQuestionID: question.id,
+              performance: result.performance,
+              fieldAverage: average,
+              delta: delta,
+              ratingAfter: ratingAfter,
+              createdAt: now
+            )
+          }.execute(db)
+        }
+      }
+    }
+  }
+
+  /// Reverses rating deltas and deletes ledger rows for a question so it can be settled again.
+  static func invalidateQuestion(
+    questionID: UUID,
+    database: PostgresClient
+  ) async throws {
+    try await database.withTransaction { db in
+      try await invalidateQuestion(questionID: questionID, db: db)
+    }
+  }
+
+  static func invalidateQuestion(
+    questionID: UUID,
+    db: any Database.Connection.`Protocol`
+  ) async throws {
+    let lockQuestion: QueryFragment =
+      "SELECT id FROM public.event_questions WHERE id = \(questionID, as: UUID.self) FOR UPDATE"
+    try await db.executeFragment(lockQuestion)
+
+    let entries =
+      try await UserRatingLedgerRecord
+      .where { $0.eventQuestionID.eq(questionID) }
+      .fetchAll(db)
+    let now = Date()
+    for entry in entries {
+      let reverse: QueryFragment = """
+        UPDATE public.user_season_ratings
+        SET rating = rating - \(entry.delta, as: Int.self),
+            updated_at = \(now, as: Date.self)
+        WHERE user_id = \(entry.userID, as: UUID.self)
+          AND season_id = \(entry.seasonID, as: UUID.self)
+        """
+      try await db.executeFragment(reverse)
+    }
+    let deleteLedger: QueryFragment =
+      "DELETE FROM public.user_rating_ledger WHERE event_question_id = \(questionID, as: UUID.self)"
+    try await db.executeFragment(deleteLedger)
+  }
+
+  static func seasonForSettlement(
+    at publishedAt: Date,
+    db: any Database.Connection.`Protocol`
+  ) async throws -> RatingSeasonRecord? {
+    let seasons =
+      try await RatingSeasonRecord
+      .order { ($0.startsAt.desc(), $0.id.desc()) }
+      .fetchAll(db)
+    return seasons.first { season in
+      guard season.startsAt <= publishedAt else { return false }
+      if let endsAt = season.endsAt {
+        return endsAt > publishedAt
+      }
+      return true
+    }
+  }
+}

--- a/Tests/AppTests/EventScoringRouterTests.swift
+++ b/Tests/AppTests/EventScoringRouterTests.swift
@@ -50,28 +50,6 @@ struct EventScoringRouterTests {
       let highScorer = try await createUser()
       let lowScorer = try await createUser()
 
-      guard let organizerID = UUID(uuidString: organizer.userID) else {
-        Issue.record("organizer userID is not a UUID")
-        return
-      }
-      AdminUserIDs.testOverride.withLock { $0 = [organizerID] }
-      defer { AdminUserIDs.testOverride.withLock { $0 = nil } }
-
-      let seasonResponse = try await client.execute(
-        uri: "/ratings/seasons",
-        method: .post,
-        headers: [
-          .cfConnectingIP: ipAddress,
-          .authorization: "Bearer \(organizer.token)",
-        ],
-        body: ByteBuffer(
-          data: try encoder.encode(
-            Components.Schemas.CreateRatingSeasonRequest(name: "Season \(UUID())")
-          )
-        )
-      )
-      #expect(seasonResponse.status == .ok)
-
       let event = try await client.execute(
         uri: "/events",
         method: .post,

--- a/Tests/AppTests/EventScoringRouterTests.swift
+++ b/Tests/AppTests/EventScoringRouterTests.swift
@@ -1,0 +1,359 @@
+import Foundation
+import HummingbirdTesting
+import NIOCore
+import Testing
+
+@testable import App
+
+@Suite(.serialized)
+struct EventScoringRouterTests {
+  @Test
+  func eventScoresExcludeOrganizerAndSettleRatings() async throws {
+    let arguments = TestArguments()
+    let app = try await buildApplication(arguments)
+    let ipAddress = UUID().uuidString
+    let now = Date().timeIntervalSinceReferenceDate
+    let encoder = JSONEncoder()
+    let decoder = JSONDecoder()
+
+    try await app.test(.router) { client in
+      func createUser() async throws -> Components.Schemas.UserToken {
+        try await client.execute(
+          uri: "/user",
+          method: .post,
+          headers: [.cfConnectingIP: ipAddress]
+        ) { response in
+          #expect(response.status == .ok)
+          return try decoder.decode(Components.Schemas.UserToken.self, from: response.body)
+        }
+      }
+
+      func eventRequest(
+        startsAt: Double,
+        responsesDueAt: Double,
+        answersPublishedAt: Double
+      ) -> Components.Schemas.CreateEventRequest {
+        .init(
+          title: "Scoring integration",
+          body: "Score and rating flow",
+          venueName: "Blind Tasting Room",
+          venueAddress: .init(addressLine1: "1 Wine Street", countryCode: "JP"),
+          eventPeriod: .init(startsAt: startsAt, endsAt: startsAt + 3600),
+          responsesDueAt: responsesDueAt,
+          answersPublishedAt: answersPublishedAt,
+          visibility: ._public,
+          publishedAt: startsAt - 100
+        )
+      }
+
+      let organizer = try await createUser()
+      let highScorer = try await createUser()
+      let lowScorer = try await createUser()
+
+      guard let organizerID = UUID(uuidString: organizer.userID) else {
+        Issue.record("organizer userID is not a UUID")
+        return
+      }
+      AdminUserIDs.testOverride.withLock { $0 = [organizerID] }
+      defer { AdminUserIDs.testOverride.withLock { $0 = nil } }
+
+      let seasonResponse = try await client.execute(
+        uri: "/ratings/seasons",
+        method: .post,
+        headers: [
+          .cfConnectingIP: ipAddress,
+          .authorization: "Bearer \(organizer.token)",
+        ],
+        body: ByteBuffer(
+          data: try encoder.encode(
+            Components.Schemas.CreateRatingSeasonRequest(name: "Season \(UUID())")
+          )
+        )
+      )
+      #expect(seasonResponse.status == .ok)
+
+      let event = try await client.execute(
+        uri: "/events",
+        method: .post,
+        headers: [
+          .cfConnectingIP: ipAddress,
+          .authorization: "Bearer \(organizer.token)",
+        ],
+        body: ByteBuffer(
+          data: try encoder.encode(
+            eventRequest(
+              startsAt: now - 100,
+              responsesDueAt: now + 3600,
+              answersPublishedAt: now + 7200
+            )
+          )
+        )
+      ) { response in
+        #expect(response.status == .ok)
+        return try decoder.decode(Components.Schemas.Event.self, from: response.body)
+      }
+
+      for participant in [highScorer, lowScorer] {
+        let join = try await client.execute(
+          uri: "/events/\(event.id)/participants",
+          method: .post,
+          headers: [
+            .cfConnectingIP: ipAddress,
+            .authorization: "Bearer \(participant.token)",
+          ]
+        )
+        #expect(join.status == .ok)
+      }
+
+      let question = try await client.execute(
+        uri: "/events/\(event.id)/questions",
+        method: .post,
+        headers: [
+          .cfConnectingIP: ipAddress,
+          .authorization: "Bearer \(organizer.token)",
+        ],
+        body: ByteBuffer(
+          data: try encoder.encode(
+            Components.Schemas.CreateEventQuestionRequest(
+              questionNumber: 1,
+              scoreComponentRules: [
+                .init(component: .vintage, points: 10)
+              ]
+            )
+          )
+        )
+      ) { response in
+        #expect(response.status == .ok)
+        return try decoder.decode(Components.Schemas.EventQuestion.self, from: response.body)
+      }
+
+      let createAnswer = try await client.execute(
+        uri: "/events/\(event.id)/questions/\(question.id)/correct_answer",
+        method: .post,
+        headers: [
+          .cfConnectingIP: ipAddress,
+          .authorization: "Bearer \(organizer.token)",
+        ],
+        body: ByteBuffer(
+          data: try encoder.encode(
+            Components.Schemas.CreateEventQuestionCorrectAnswerRequest(
+              vintage: 2015,
+              wineVarietyIDs: []
+            )
+          )
+        )
+      )
+      #expect(createAnswer.status == .ok)
+
+      func submitResponse(token: String, vintage: Int32) async throws {
+        let response = try await client.execute(
+          uri: "/events/\(event.id)/questions/\(question.id)/responses",
+          method: .post,
+          headers: [
+            .cfConnectingIP: ipAddress,
+            .authorization: "Bearer \(token)",
+          ],
+          body: ByteBuffer(
+            data: try encoder.encode(
+              Components.Schemas.CreateEventQuestionResponseRequest(
+                vintage: vintage,
+                wineVarietyIDs: []
+              )
+            )
+          )
+        )
+        #expect(response.status == .ok)
+      }
+
+      try await submitResponse(token: organizer.token, vintage: 2015)
+      try await submitResponse(token: highScorer.token, vintage: 2015)
+      try await submitResponse(token: lowScorer.token, vintage: 2010)
+
+      let forbiddenBeforePublish = try await client.execute(
+        uri: "/events/\(event.id)/leaderboard",
+        method: .get,
+        headers: [
+          .cfConnectingIP: ipAddress,
+          .authorization: "Bearer \(highScorer.token)",
+        ]
+      )
+      #expect(forbiddenBeforePublish.status == .forbidden)
+
+      let publishedAt = Date().timeIntervalSinceReferenceDate
+      let publishUpdate = try await client.execute(
+        uri: "/events/\(event.id)",
+        method: .put,
+        headers: [
+          .cfConnectingIP: ipAddress,
+          .authorization: "Bearer \(organizer.token)",
+        ],
+        body: ByteBuffer(
+          data: try encoder.encode(
+            eventRequest(
+              startsAt: now - 100,
+              responsesDueAt: publishedAt - 1,
+              answersPublishedAt: publishedAt
+            )
+          )
+        )
+      )
+      #expect(publishUpdate.status == .ok)
+
+      let leaderboard = try await client.execute(
+        uri: "/events/\(event.id)/leaderboard",
+        method: .get,
+        headers: [
+          .cfConnectingIP: ipAddress,
+          .authorization: "Bearer \(highScorer.token)",
+        ]
+      ) { response in
+        #expect(response.status == .ok)
+        return try decoder.decode(
+          [Components.Schemas.EventLeaderboardEntry].self,
+          from: response.body
+        )
+      }
+      #expect(leaderboard.map(\.userID) == [highScorer.userID, lowScorer.userID])
+      #expect(Set(leaderboard.map(\.userID)).contains(organizer.userID) == false)
+      #expect(leaderboard[0].rank == 1)
+      #expect(leaderboard[0].totalEarnedPoints == 10)
+      #expect(leaderboard[1].rank == 2)
+      #expect(leaderboard[1].totalEarnedPoints == 0)
+
+      let eventScores = try await client.execute(
+        uri: "/events/\(event.id)/scores",
+        method: .get,
+        headers: [
+          .cfConnectingIP: ipAddress,
+          .authorization: "Bearer \(organizer.token)",
+        ]
+      ) { response in
+        #expect(response.status == .ok)
+        return try decoder.decode(
+          [Components.Schemas.EventParticipantScore].self,
+          from: response.body
+        )
+      }
+      #expect(Set(eventScores.map(\.userID)) == Set([highScorer.userID, lowScorer.userID]))
+
+      let questionScores = try await client.execute(
+        uri: "/events/\(event.id)/questions/\(question.id)/scores",
+        method: .get,
+        headers: [
+          .cfConnectingIP: ipAddress,
+          .authorization: "Bearer \(highScorer.token)",
+        ]
+      ) { response in
+        #expect(response.status == .ok)
+        return try decoder.decode(
+          [Components.Schemas.EventQuestionUserScore].self,
+          from: response.body
+        )
+      }
+      #expect(Set(questionScores.map(\.userID)) == Set([highScorer.userID, lowScorer.userID]))
+
+      let highRating = try await client.execute(
+        uri: "/me/rating",
+        method: .get,
+        headers: [
+          .cfConnectingIP: ipAddress,
+          .authorization: "Bearer \(highScorer.token)",
+        ]
+      ) { response in
+        #expect(response.status == .ok)
+        return try decoder.decode(Components.Schemas.UserRating.self, from: response.body)
+      }
+      #expect(highRating.rating == Int32(RatingSettlement.initialRating + 16))
+      #expect(highRating.recentLedger.count == 1)
+
+      let lowRating = try await client.execute(
+        uri: "/me/rating",
+        method: .get,
+        headers: [
+          .cfConnectingIP: ipAddress,
+          .authorization: "Bearer \(lowScorer.token)",
+        ]
+      ) { response in
+        #expect(response.status == .ok)
+        return try decoder.decode(Components.Schemas.UserRating.self, from: response.body)
+      }
+      #expect(lowRating.rating == Int32(RatingSettlement.initialRating - 16))
+
+      let organizerRating = try await client.execute(
+        uri: "/me/rating",
+        method: .get,
+        headers: [
+          .cfConnectingIP: ipAddress,
+          .authorization: "Bearer \(organizer.token)",
+        ]
+      ) { response in
+        #expect(response.status == .ok)
+        return try decoder.decode(Components.Schemas.UserRating.self, from: response.body)
+      }
+      #expect(organizerRating.rating == Int32(RatingSettlement.initialRating))
+      #expect(organizerRating.recentLedger.isEmpty)
+
+      let updateAnswer = try await client.execute(
+        uri: "/events/\(event.id)/questions/\(question.id)/correct_answer",
+        method: .put,
+        headers: [
+          .cfConnectingIP: ipAddress,
+          .authorization: "Bearer \(organizer.token)",
+        ],
+        body: ByteBuffer(
+          data: try encoder.encode(
+            Components.Schemas.CreateEventQuestionCorrectAnswerRequest(
+              vintage: 2010,
+              wineVarietyIDs: []
+            )
+          )
+        )
+      )
+      #expect(updateAnswer.status == .ok)
+
+      let leaderboardAfterUpdate = try await client.execute(
+        uri: "/events/\(event.id)/leaderboard",
+        method: .get,
+        headers: [
+          .cfConnectingIP: ipAddress,
+          .authorization: "Bearer \(highScorer.token)",
+        ]
+      ) { response in
+        #expect(response.status == .ok)
+        return try decoder.decode(
+          [Components.Schemas.EventLeaderboardEntry].self,
+          from: response.body
+        )
+      }
+      #expect(leaderboardAfterUpdate.map(\.userID) == [lowScorer.userID, highScorer.userID])
+      #expect(leaderboardAfterUpdate[0].totalEarnedPoints == 10)
+      #expect(leaderboardAfterUpdate[1].totalEarnedPoints == 0)
+
+      let highRatingAfterUpdate = try await client.execute(
+        uri: "/me/rating",
+        method: .get,
+        headers: [
+          .cfConnectingIP: ipAddress,
+          .authorization: "Bearer \(highScorer.token)",
+        ]
+      ) { response in
+        #expect(response.status == .ok)
+        return try decoder.decode(Components.Schemas.UserRating.self, from: response.body)
+      }
+      #expect(highRatingAfterUpdate.rating == Int32(RatingSettlement.initialRating - 16))
+
+      let lowRatingAfterUpdate = try await client.execute(
+        uri: "/me/rating",
+        method: .get,
+        headers: [
+          .cfConnectingIP: ipAddress,
+          .authorization: "Bearer \(lowScorer.token)",
+        ]
+      ) { response in
+        #expect(response.status == .ok)
+        return try decoder.decode(Components.Schemas.UserRating.self, from: response.body)
+      }
+      #expect(lowRatingAfterUpdate.rating == Int32(RatingSettlement.initialRating + 16))
+    }
+  }
+}

--- a/Tests/AppTests/RouterTests.swift
+++ b/Tests/AppTests/RouterTests.swift
@@ -646,6 +646,8 @@ struct RouterTests {
           venueName: "Blind Tasting Room",
           venueAddress: .init(addressLine1: "1 Wine Street", countryCode: "JP"),
           eventPeriod: .init(startsAt: startsAt, endsAt: startsAt + 3600),
+          responsesDueAt: startsAt + 7200,
+          answersPublishedAt: startsAt + 10_800,
           visibility: visibility,
           publishedAt: publishedAt,
           canceledAt: canceledAt

--- a/Tests/AppTests/ScoringTests.swift
+++ b/Tests/AppTests/ScoringTests.swift
@@ -230,7 +230,7 @@ struct ScoringTests {
   }
 
   @Test
-  func producerPartialDoesNotAwardBlankBlankOrDoubleFeature() {
+  func producerBlankIsZeroAndFeaturePartialDoesNotDoubleCount() {
     let producerID = UUID()
     let producerRule = EventQuestionScoreComponentRuleRecord(
       eventQuestionID: UUID(),
@@ -296,7 +296,24 @@ struct ScoringTests {
       correctRegionAncestors: [],
       responseRegionAncestors: []
     )
-    #expect(anonymous.earnedPoints == 2)
+    #expect(anonymous.earnedPoints == 0)
+
+    let featurePartialWithoutSeparateRule = QuestionScorer.score(
+      correct: correct,
+      response: ScoringAnswerPayload(
+        wineRegionID: nil,
+        producerWineRegionID: UUID(),
+        feature: "granite",
+        vintage: nil,
+        alcoholByVolume: nil,
+        wineVarietyIDs: []
+      ),
+      regionRules: [],
+      componentRules: [producerRule],
+      correctRegionAncestors: [],
+      responseRegionAncestors: []
+    )
+    #expect(featurePartialWithoutSeparateRule.earnedPoints == 2)
 
     let withSeparateFeatureRule = QuestionScorer.score(
       correct: correct,

--- a/Tests/AppTests/ScoringTests.swift
+++ b/Tests/AppTests/ScoringTests.swift
@@ -41,6 +41,23 @@ struct ScoringTests {
     )
     #expect(exact.earnedPoints == 2)
 
+    let nearExact = QuestionScorer.score(
+      correct: correct,
+      response: ScoringAnswerPayload(
+        wineRegionID: nil,
+        producerWineRegionID: nil,
+        feature: nil,
+        vintage: nil,
+        alcoholByVolume: 13.0 + 1e-12,
+        wineVarietyIDs: []
+      ),
+      regionRules: [],
+      componentRules: [rule],
+      correctRegionAncestors: [],
+      responseRegionAncestors: []
+    )
+    #expect(nearExact.earnedPoints == 2)
+
     let partial = QuestionScorer.score(
       correct: correct,
       response: ScoringAnswerPayload(
@@ -134,7 +151,7 @@ struct ScoringTests {
   }
 
   @Test
-  func varietyRequiresExactSetMatch() {
+  func varietyRequiresNonEmptyExactSetMatch() {
     let a = UUID()
     let b = UUID()
     let rule = EventQuestionScoreComponentRuleRecord(
@@ -170,6 +187,30 @@ struct ScoringTests {
     )
     #expect(match.earnedPoints == 4)
 
+    let emptyBoth = QuestionScorer.score(
+      correct: ScoringAnswerPayload(
+        wineRegionID: nil,
+        producerWineRegionID: nil,
+        feature: nil,
+        vintage: nil,
+        alcoholByVolume: nil,
+        wineVarietyIDs: []
+      ),
+      response: ScoringAnswerPayload(
+        wineRegionID: nil,
+        producerWineRegionID: nil,
+        feature: nil,
+        vintage: nil,
+        alcoholByVolume: nil,
+        wineVarietyIDs: []
+      ),
+      regionRules: [],
+      componentRules: [rule],
+      correctRegionAncestors: [],
+      responseRegionAncestors: []
+    )
+    #expect(emptyBoth.earnedPoints == 0)
+
     let miss = QuestionScorer.score(
       correct: correct,
       response: ScoringAnswerPayload(
@@ -189,10 +230,112 @@ struct ScoringTests {
   }
 
   @Test
+  func producerPartialDoesNotAwardBlankBlankOrDoubleFeature() {
+    let producerID = UUID()
+    let producerRule = EventQuestionScoreComponentRuleRecord(
+      eventQuestionID: UUID(),
+      component: .producer,
+      points: 4,
+      partialPoints: 2,
+      alcoholTolerance: nil,
+      createdAt: Date()
+    )
+    let featureRule = EventQuestionScoreComponentRuleRecord(
+      eventQuestionID: UUID(),
+      component: .feature,
+      points: 2,
+      partialPoints: nil,
+      alcoholTolerance: nil,
+      createdAt: Date()
+    )
+    let correct = ScoringAnswerPayload(
+      wineRegionID: nil,
+      producerWineRegionID: producerID,
+      feature: "Granite",
+      vintage: nil,
+      alcoholByVolume: nil,
+      wineVarietyIDs: []
+    )
+
+    let blankBlank = QuestionScorer.score(
+      correct: ScoringAnswerPayload(
+        wineRegionID: nil,
+        producerWineRegionID: nil,
+        feature: nil,
+        vintage: nil,
+        alcoholByVolume: nil,
+        wineVarietyIDs: []
+      ),
+      response: ScoringAnswerPayload(
+        wineRegionID: nil,
+        producerWineRegionID: nil,
+        feature: nil,
+        vintage: nil,
+        alcoholByVolume: nil,
+        wineVarietyIDs: []
+      ),
+      regionRules: [],
+      componentRules: [producerRule],
+      correctRegionAncestors: [],
+      responseRegionAncestors: []
+    )
+    #expect(blankBlank.earnedPoints == 0)
+
+    let anonymous = QuestionScorer.score(
+      correct: correct,
+      response: ScoringAnswerPayload(
+        wineRegionID: nil,
+        producerWineRegionID: nil,
+        feature: nil,
+        vintage: nil,
+        alcoholByVolume: nil,
+        wineVarietyIDs: []
+      ),
+      regionRules: [],
+      componentRules: [producerRule],
+      correctRegionAncestors: [],
+      responseRegionAncestors: []
+    )
+    #expect(anonymous.earnedPoints == 2)
+
+    let withSeparateFeatureRule = QuestionScorer.score(
+      correct: correct,
+      response: ScoringAnswerPayload(
+        wineRegionID: nil,
+        producerWineRegionID: UUID(),
+        feature: "granite",
+        vintage: nil,
+        alcoholByVolume: nil,
+        wineVarietyIDs: []
+      ),
+      regionRules: [],
+      componentRules: [producerRule, featureRule],
+      correctRegionAncestors: [],
+      responseRegionAncestors: []
+    )
+    #expect(withSeparateFeatureRule.earnedPoints == 2)
+    #expect(
+      withSeparateFeatureRule.components.first { $0.component == .producer }?.earnedPoints == 0
+    )
+    #expect(
+      withSeparateFeatureRule.components.first { $0.component == .feature }?.earnedPoints == 2
+    )
+  }
+
+  @Test
   func ratingDeltaGrowsWhenPerformanceIsRare() {
     #expect(RatingCalculator.delta(performance: 1, fieldAverage: 0) == 32)
     #expect(RatingCalculator.delta(performance: 1, fieldAverage: 1) == 0)
     #expect(RatingCalculator.delta(performance: 0, fieldAverage: 1) == -32)
     #expect(RatingCalculator.delta(performance: 1, fieldAverage: 0.5) == 16)
+  }
+
+  @Test
+  func competitionRankingSharesTies() {
+    let rows = [
+      (id: "a", score: 10), (id: "b", score: 8), (id: "c", score: 8), (id: "d", score: 5),
+    ]
+    let ranked = Ranking.competitionRanks(rows) { $0.score }
+    #expect(ranked.map(\.rank) == [1, 2, 2, 4])
   }
 }

--- a/Tests/AppTests/ScoringTests.swift
+++ b/Tests/AppTests/ScoringTests.swift
@@ -1,0 +1,198 @@
+import Foundation
+import Testing
+
+@testable import App
+
+@Suite
+struct ScoringTests {
+  @Test
+  func alcoholExactAndPartialAndMiss() {
+    let rule = EventQuestionScoreComponentRuleRecord(
+      eventQuestionID: UUID(),
+      component: .alcohol,
+      points: 2,
+      partialPoints: 1,
+      alcoholTolerance: 0.5,
+      createdAt: Date()
+    )
+    let correct = ScoringAnswerPayload(
+      wineRegionID: nil,
+      producerWineRegionID: nil,
+      feature: nil,
+      vintage: nil,
+      alcoholByVolume: 13.0,
+      wineVarietyIDs: []
+    )
+
+    let exact = QuestionScorer.score(
+      correct: correct,
+      response: ScoringAnswerPayload(
+        wineRegionID: nil,
+        producerWineRegionID: nil,
+        feature: nil,
+        vintage: nil,
+        alcoholByVolume: 13.0,
+        wineVarietyIDs: []
+      ),
+      regionRules: [],
+      componentRules: [rule],
+      correctRegionAncestors: [],
+      responseRegionAncestors: []
+    )
+    #expect(exact.earnedPoints == 2)
+
+    let partial = QuestionScorer.score(
+      correct: correct,
+      response: ScoringAnswerPayload(
+        wineRegionID: nil,
+        producerWineRegionID: nil,
+        feature: nil,
+        vintage: nil,
+        alcoholByVolume: 13.4,
+        wineVarietyIDs: []
+      ),
+      regionRules: [],
+      componentRules: [rule],
+      correctRegionAncestors: [],
+      responseRegionAncestors: []
+    )
+    #expect(partial.earnedPoints == 1)
+
+    let miss = QuestionScorer.score(
+      correct: correct,
+      response: ScoringAnswerPayload(
+        wineRegionID: nil,
+        producerWineRegionID: nil,
+        feature: nil,
+        vintage: nil,
+        alcoholByVolume: 14.0,
+        wineVarietyIDs: []
+      ),
+      regionRules: [],
+      componentRules: [rule],
+      correctRegionAncestors: [],
+      responseRegionAncestors: []
+    )
+    #expect(miss.earnedPoints == 0)
+  }
+
+  @Test
+  func regionAncestorPartialCreditUsesDeepestMatch() {
+    let countryType = UUID()
+    let communeType = UUID()
+    let countryID = UUID()
+    let communeID = UUID()
+    let rules = [
+      EventQuestionRegionScoreRuleRecord(
+        eventQuestionID: UUID(),
+        wineRegionTypeID: countryType,
+        points: 1,
+        createdAt: Date()
+      ),
+      EventQuestionRegionScoreRuleRecord(
+        eventQuestionID: UUID(),
+        wineRegionTypeID: communeType,
+        points: 2,
+        createdAt: Date()
+      ),
+    ]
+    let correctAncestors = [
+      RegionAncestor(id: communeID, wineRegionTypeID: communeType),
+      RegionAncestor(id: countryID, wineRegionTypeID: countryType),
+    ]
+    let empty = ScoringAnswerPayload(
+      wineRegionID: nil,
+      producerWineRegionID: nil,
+      feature: nil,
+      vintage: nil,
+      alcoholByVolume: nil,
+      wineVarietyIDs: []
+    )
+
+    let full = QuestionScorer.score(
+      correct: empty,
+      response: empty,
+      regionRules: rules,
+      componentRules: [],
+      correctRegionAncestors: correctAncestors,
+      responseRegionAncestors: correctAncestors
+    )
+    #expect(full.earnedPoints == 2)
+    #expect(full.maxPoints == 2)
+
+    let partial = QuestionScorer.score(
+      correct: empty,
+      response: empty,
+      regionRules: rules,
+      componentRules: [],
+      correctRegionAncestors: correctAncestors,
+      responseRegionAncestors: [
+        RegionAncestor(id: countryID, wineRegionTypeID: countryType)
+      ]
+    )
+    #expect(partial.earnedPoints == 1)
+  }
+
+  @Test
+  func varietyRequiresExactSetMatch() {
+    let a = UUID()
+    let b = UUID()
+    let rule = EventQuestionScoreComponentRuleRecord(
+      eventQuestionID: UUID(),
+      component: .variety,
+      points: 4,
+      partialPoints: nil,
+      alcoholTolerance: nil,
+      createdAt: Date()
+    )
+    let correct = ScoringAnswerPayload(
+      wineRegionID: nil,
+      producerWineRegionID: nil,
+      feature: nil,
+      vintage: nil,
+      alcoholByVolume: nil,
+      wineVarietyIDs: [a, b]
+    )
+    let match = QuestionScorer.score(
+      correct: correct,
+      response: ScoringAnswerPayload(
+        wineRegionID: nil,
+        producerWineRegionID: nil,
+        feature: nil,
+        vintage: nil,
+        alcoholByVolume: nil,
+        wineVarietyIDs: [b, a]
+      ),
+      regionRules: [],
+      componentRules: [rule],
+      correctRegionAncestors: [],
+      responseRegionAncestors: []
+    )
+    #expect(match.earnedPoints == 4)
+
+    let miss = QuestionScorer.score(
+      correct: correct,
+      response: ScoringAnswerPayload(
+        wineRegionID: nil,
+        producerWineRegionID: nil,
+        feature: nil,
+        vintage: nil,
+        alcoholByVolume: nil,
+        wineVarietyIDs: [a]
+      ),
+      regionRules: [],
+      componentRules: [rule],
+      correctRegionAncestors: [],
+      responseRegionAncestors: []
+    )
+    #expect(miss.earnedPoints == 0)
+  }
+
+  @Test
+  func ratingDeltaGrowsWhenPerformanceIsRare() {
+    #expect(RatingCalculator.delta(performance: 1, fieldAverage: 0) == 32)
+    #expect(RatingCalculator.delta(performance: 1, fieldAverage: 1) == 0)
+    #expect(RatingCalculator.delta(performance: 0, fieldAverage: 1) == -32)
+    #expect(RatingCalculator.delta(performance: 1, fieldAverage: 0.5) == 16)
+  }
+}

--- a/compose.yml
+++ b/compose.yml
@@ -14,6 +14,7 @@ services:
       - ./Database/extensions.sql:/docker-entrypoint-initdb.d/001_extensions.sql:ro
       - ./Database/schema.sql:/docker-entrypoint-initdb.d/002_schema.sql:ro
       - ./Database/migrations/20260531060000_seed_wine_master_data.sql:/docker-entrypoint-initdb.d/003_seed_wine_master_data.sql:ro
+      - ./Database/seeds/006_rating_seasons.sql:/docker-entrypoint-initdb.d/004_rating_seasons.sql:ro
 
   otel-collector:
     image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.155.0

--- a/public/app.js
+++ b/public/app.js
@@ -593,6 +593,8 @@
         startsAt: referenceSecondsFromInput(val('event-period-start')),
         endsAt: referenceSecondsFromInput(val('event-period-end')),
       };
+      body.responsesDueAt = referenceSecondsFromInput(val('event-responses-due-at'));
+      body.answersPublishedAt = referenceSecondsFromInput(val('event-answer-published-at'));
 
       const registrationStart = referenceSecondsFromInput(val('event-registration-start'));
       const registrationEnd = referenceSecondsFromInput(val('event-registration-end'));
@@ -600,7 +602,6 @@
         body.registrationPeriod = { startsAt: registrationStart, endsAt: registrationEnd };
       }
 
-      assignIfPresent(body, 'answersPublishedAt', referenceSecondsFromInput(val('event-answer-published-at')));
       const capacity = readNumber(val('event-capacity'));
       assignIfPresent(body, 'capacity', capacity === null ? null : Math.round(capacity));
 
@@ -622,6 +623,18 @@
         { predicate: () => body.venueAddress.countryCode.length > 0, message: '国コードを入力してください。' },
         { predicate: () => body.eventPeriod.startsAt !== null, message: '開催開始日時を入力してください。' },
         { predicate: () => body.eventPeriod.endsAt !== null, message: '開催終了日時を入力してください。' },
+        { predicate: () => body.responsesDueAt !== null, message: '回答期限を入力してください。' },
+        { predicate: () => body.answersPublishedAt !== null, message: '正解公開日時を入力してください。' },
+        {
+          predicate: () => body.responsesDueAt === null || body.eventPeriod.startsAt === null
+            || body.eventPeriod.startsAt <= body.responsesDueAt,
+          message: '回答期限は開催開始以降にしてください。',
+        },
+        {
+          predicate: () => body.answersPublishedAt === null || body.responsesDueAt === null
+            || body.responsesDueAt <= body.answersPublishedAt,
+          message: '正解公開は回答期限以降にしてください。',
+        },
       ]);
     }
 
@@ -993,6 +1006,7 @@
       const dl = document.createElement('dl');
       dl.className = 'event-meta';
       appendMetaRow(dl, '開催', formatPeriod(event?.eventPeriod));
+      appendMetaRow(dl, '回答期限', formatDateTime(event?.responsesDueAt));
       const venue = [event?.venueName, formatAddress(event?.venueAddress)].filter(Boolean).join(' / ');
       appendMetaRow(dl, '会場', venue || null);
       appendMetaRow(dl, '受付', formatPeriod(event?.registrationPeriod));
@@ -1088,7 +1102,8 @@
         'event-address-line1', 'event-address-line2', 'event-locality',
         'event-administrative-area', 'event-postal-code', 'event-country-code',
         'event-latitude', 'event-longitude', 'event-period-start', 'event-period-end',
-        'event-registration-start', 'event-registration-end', 'event-answer-published-at',
+        'event-registration-start', 'event-registration-end', 'event-responses-due-at',
+        'event-answer-published-at',
         'event-capacity', 'event-fee-amount', 'event-fee-currency', 'event-id',
       ]) setVal(id, '');
       setVal('event-visibility', 'private');
@@ -1114,6 +1129,7 @@
       setVal('event-period-end', inputFromReferenceSeconds(event?.eventPeriod?.endsAt));
       setVal('event-registration-start', inputFromReferenceSeconds(event?.registrationPeriod?.startsAt));
       setVal('event-registration-end', inputFromReferenceSeconds(event?.registrationPeriod?.endsAt));
+      setVal('event-responses-due-at', inputFromReferenceSeconds(event?.responsesDueAt));
       setVal('event-answer-published-at', inputFromReferenceSeconds(event?.answersPublishedAt));
       setVal('event-capacity', event?.capacity ?? '');
       setVal('event-fee-amount', event?.entryFee?.minorAmount ?? '');

--- a/public/documents/openapi.yml
+++ b/public/documents/openapi.yml
@@ -1371,7 +1371,7 @@ paths:
       tags:
         - Events
       summary: List event participant scores
-      description: Returns per-participant score totals and per-question score summaries for an event.
+      description: Returns per-participant score totals and per-question score summaries for an event. The event organizer is excluded even if they submitted a response.
       security:
         - bearerAuth: []
       parameters:
@@ -1421,7 +1421,7 @@ paths:
       tags:
         - Events
       summary: Get event leaderboard
-      description: Returns ranked participant scores for an event.
+      description: Returns ranked participant scores for an event. The event organizer is excluded even if they submitted a response.
       security:
         - bearerAuth: []
       parameters:
@@ -1471,7 +1471,7 @@ paths:
       tags:
         - Events
       summary: List question scores
-      description: Returns per-user scores and score component breakdown for a question.
+      description: Returns per-user scores and score component breakdown for a question. The event organizer is excluded even if they submitted a response.
       security:
         - bearerAuth: []
       parameters:
@@ -2581,6 +2581,7 @@ components:
         submittedAt:
           type: number
           format: double
+          description: Instant of the latest response revision, as Foundation reference date seconds.
       required:
         - id
         - eventQuestionID

--- a/public/documents/openapi.yml
+++ b/public/documents/openapi.yml
@@ -1410,7 +1410,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/APIError'
         '403':
-          description: Answers are not published yet
+          description: Answers are not published yet, or the caller is not an organizer or participant
           content:
             application/json:
               schema:
@@ -1460,7 +1460,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/APIError'
         '403':
-          description: Answers are not published yet
+          description: Answers are not published yet, or the caller is not an organizer or participant
           content:
             application/json:
               schema:
@@ -1517,7 +1517,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/APIError'
         '403':
-          description: Answers are not published yet
+          description: Answers are not published yet, or the caller is not an organizer or participant
           content:
             application/json:
               schema:
@@ -1546,6 +1546,12 @@ paths:
                 $ref: '#/components/schemas/APIError'
         '401':
           description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+        '404':
+          description: No active rating season
           content:
             application/json:
               schema:
@@ -1600,7 +1606,7 @@ paths:
       tags:
         - Ratings
       summary: Create rating season
-      description: Creates a new rating season.
+      description: Creates a new rating season and closes the previously active season by setting its ends_at.
       security:
         - bearerAuth: []
       requestBody:
@@ -1624,6 +1630,12 @@ paths:
                 $ref: '#/components/schemas/APIError'
         '401':
           description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+        '403':
+          description: Forbidden — caller is not an admin user
           content:
             application/json:
               schema:

--- a/public/documents/openapi.yml
+++ b/public/documents/openapi.yml
@@ -18,6 +18,8 @@ tags:
     description: Cloudflare Images direct upload and image registration endpoints.
   - name: Events
     description: Blind tasting event, participant, question, answer, and response endpoints.
+  - name: Ratings
+    description: Seasonal rating, ledger, and rating leaderboard endpoints.
   - name: Wine Master Data
     description: Read-only wine style, variety, and region reference data.
 paths:
@@ -602,7 +604,7 @@ paths:
       tags:
         - Events
       summary: Create event
-      description: Creates a blind tasting event with venue, schedule, visibility, and scoring rule settings.
+      description: Creates a blind tasting event with venue, schedule, visibility, and response deadlines.
       security:
         - bearerAuth: []
       requestBody:
@@ -1363,6 +1365,269 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/APIError'
+  /events/{event_id}/scores:
+    get:
+      operationId: getEventScores
+      tags:
+        - Events
+      summary: List event participant scores
+      description: Returns per-participant score totals and per-question score summaries for an event.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: event_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: Target event ID in UUID format.
+      responses:
+        '200':
+          description: A success response with participant scores for the event.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/EventParticipantScore'
+        '400':
+          description: A bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+        '404':
+          description: Not found Event
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+        '403':
+          description: Answers are not published yet
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+  /events/{event_id}/leaderboard:
+    get:
+      operationId: getEventLeaderboard
+      tags:
+        - Events
+      summary: Get event leaderboard
+      description: Returns ranked participant scores for an event.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: event_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: Target event ID in UUID format.
+      responses:
+        '200':
+          description: A success response with the event leaderboard.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/EventLeaderboardEntry'
+        '400':
+          description: A bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+        '404':
+          description: Not found Event
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+        '403':
+          description: Answers are not published yet
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+  /events/{event_id}/questions/{question_id}/scores:
+    get:
+      operationId: getEventQuestionScores
+      tags:
+        - Events
+      summary: List question scores
+      description: Returns per-user scores and score component breakdown for a question.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: event_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: Target event ID in UUID format.
+        - name: question_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: Target event question ID in UUID format.
+      responses:
+        '200':
+          description: A success response with per-user scores for the question.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/EventQuestionUserScore'
+        '400':
+          description: A bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+        '404':
+          description: Not found Event Question
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+        '403':
+          description: Answers are not published yet
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+  /me/rating:
+    get:
+      operationId: getMyRating
+      tags:
+        - Ratings
+      summary: Get my rating
+      description: Returns the authenticated user's current seasonal rating and recent rating ledger entries.
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: A success response with the authenticated user's rating.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserRating'
+        '400':
+          description: A bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+  /ratings/leaderboard:
+    get:
+      operationId: getRatingLeaderboard
+      tags:
+        - Ratings
+      summary: Get rating leaderboard
+      description: Returns ranked user ratings for a season. When season_id is omitted, the current season is used.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: season_id
+          in: query
+          required: false
+          schema:
+            type: string
+            format: uuid
+          description: Optional rating season ID in UUID format. Defaults to the current season when omitted.
+      responses:
+        '200':
+          description: A success response with the rating leaderboard.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/RatingLeaderboardEntry'
+        '400':
+          description: A bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+        '404':
+          description: Not found Rating Season
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+  /rating_seasons:
+    post:
+      operationId: createRatingSeason
+      tags:
+        - Ratings
+      summary: Create rating season
+      description: Creates a new rating season.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateRatingSeasonRequest'
+      responses:
+        '200':
+          description: A success response with the created rating season.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RatingSeason'
+        '400':
+          description: A bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
   /wine/styles:
     get:
       operationId: getWineStyles
@@ -1810,9 +2075,14 @@ components:
           $ref: '#/components/schemas/DateTimePeriod'
         eventPeriod:
           $ref: '#/components/schemas/DateTimePeriod'
+        responsesDueAt:
+          type: number
+          format: double
+          description: Deadline for submitting responses, as Foundation reference date seconds.
         answersPublishedAt:
           type: number
           format: double
+          description: Instant when answers are published, as Foundation reference date seconds.
         capacity:
           type: integer
           format: int32
@@ -1826,10 +2096,6 @@ components:
         canceledAt:
           type: number
           format: double
-        regionScoreRules:
-          type: array
-          items:
-            $ref: '#/components/schemas/EventRegionScoreRule'
         createdAt:
           type: number
           format: double
@@ -1841,8 +2107,9 @@ components:
         - venueName
         - venueAddress
         - eventPeriod
+        - responsesDueAt
+        - answersPublishedAt
         - visibility
-        - regionScoreRules
         - createdAt
     CreateEventRequest:
       type: object
@@ -1865,12 +2132,14 @@ components:
           $ref: '#/components/schemas/DateTimePeriod'
         eventPeriod:
           $ref: '#/components/schemas/DateTimePeriod'
-        answersPublishedAt:
-          type:
-            - number
-            - 'null'
+        responsesDueAt:
+          type: number
           format: double
-          description: For PUT requests, omit or set null to clear.
+          description: Deadline for submitting responses, as Foundation reference date seconds.
+        answersPublishedAt:
+          type: number
+          format: double
+          description: Instant when answers are published, as Foundation reference date seconds.
         capacity:
           type: integer
           format: int32
@@ -1890,20 +2159,18 @@ components:
             - 'null'
           format: double
           description: For PUT requests, omit or set null to clear.
-        regionScoreRules:
-          type: array
-          items:
-            $ref: '#/components/schemas/CreateEventRegionScoreRuleRequest'
       required:
         - title
         - body
         - venueName
         - venueAddress
         - eventPeriod
+        - responsesDueAt
+        - answersPublishedAt
         - visibility
-    EventRegionScoreRule:
+    QuestionRegionScoreRule:
       type: object
-      description: A point rule for matching a wine region type in an event.
+      description: A point rule for matching a wine region type for a question.
       properties:
         wineRegionTypeID:
           type: string
@@ -1919,9 +2186,9 @@ components:
         - wineRegionTypeID
         - points
         - createdAt
-    CreateEventRegionScoreRuleRequest:
+    CreateQuestionRegionScoreRuleRequest:
       type: object
-      description: A request item for an event wine region type score rule.
+      description: A request item for a question wine region type score rule.
       properties:
         wineRegionTypeID:
           type: string
@@ -1932,6 +2199,64 @@ components:
           minimum: 0
       required:
         - wineRegionTypeID
+        - points
+    QuestionScoreComponentRule:
+      type: object
+      description: A point rule for a non-region score component on a question.
+      properties:
+        component:
+          type: string
+          enum:
+            - variety
+            - vintage
+            - alcohol
+            - producer
+            - feature
+        points:
+          type: integer
+          format: int32
+          minimum: 0
+        partialPoints:
+          type: integer
+          format: int32
+          minimum: 0
+        alcoholTolerance:
+          type: number
+          format: double
+          minimum: 0
+        createdAt:
+          type: number
+          format: double
+      required:
+        - component
+        - points
+        - createdAt
+    CreateQuestionScoreComponentRuleRequest:
+      type: object
+      description: A request item for a non-region score component rule on a question.
+      properties:
+        component:
+          type: string
+          enum:
+            - variety
+            - vintage
+            - alcohol
+            - producer
+            - feature
+        points:
+          type: integer
+          format: int32
+          minimum: 0
+        partialPoints:
+          type: integer
+          format: int32
+          minimum: 0
+        alcoholTolerance:
+          type: number
+          format: double
+          minimum: 0
+      required:
+        - component
         - points
     DateTimePeriod:
       type: object
@@ -2060,6 +2385,14 @@ components:
           description: Cloudflare Images delivery URL for the question image, when an image is set.
         note:
           type: string
+        regionScoreRules:
+          type: array
+          items:
+            $ref: '#/components/schemas/QuestionRegionScoreRule'
+        scoreComponentRules:
+          type: array
+          items:
+            $ref: '#/components/schemas/QuestionScoreComponentRule'
         createdAt:
           type: number
           format: double
@@ -2067,6 +2400,8 @@ components:
         - id
         - eventID
         - questionNumber
+        - regionScoreRules
+        - scoreComponentRules
         - createdAt
     CreateEventQuestionRequest:
       type: object
@@ -2080,6 +2415,16 @@ components:
           format: uuid
         note:
           type: string
+        regionScoreRules:
+          type: array
+          description: Optional region score rules. Defaults to an empty array when omitted.
+          items:
+            $ref: '#/components/schemas/CreateQuestionRegionScoreRuleRequest'
+        scoreComponentRules:
+          type: array
+          description: Optional score component rules. Defaults to an empty array when omitted.
+          items:
+            $ref: '#/components/schemas/CreateQuestionScoreComponentRuleRequest'
       required:
         - questionNumber
     CreateEventQuestionCorrectAnswerRequest:
@@ -2087,6 +2432,9 @@ components:
       description: A request to create the correct answer for a question.
       properties:
         wineRegionID:
+          type: string
+          format: uuid
+        producerWineRegionID:
           type: string
           format: uuid
         vintage:
@@ -2098,6 +2446,8 @@ components:
           format: double
           minimum: 0
           maximum: 100
+        feature:
+          type: string
         wineVarietyIDs:
           type: array
           uniqueItems: true
@@ -2119,6 +2469,9 @@ components:
         wineRegionID:
           type: string
           format: uuid
+        producerWineRegionID:
+          type: string
+          format: uuid
         vintage:
           type: integer
           format: int32
@@ -2128,6 +2481,8 @@ components:
           format: double
           minimum: 0
           maximum: 100
+        feature:
+          type: string
         wineVarietyIDs:
           type: array
           uniqueItems: true
@@ -2149,6 +2504,9 @@ components:
         wineRegionID:
           type: string
           format: uuid
+        producerWineRegionID:
+          type: string
+          format: uuid
         vintage:
           type: integer
           format: int32
@@ -2158,6 +2516,8 @@ components:
           format: double
           minimum: 0
           maximum: 100
+        feature:
+          type: string
         note:
           type: string
         wineVarietyIDs:
@@ -2184,6 +2544,9 @@ components:
         wineRegionID:
           type: string
           format: uuid
+        producerWineRegionID:
+          type: string
+          format: uuid
         vintage:
           type: integer
           format: int32
@@ -2193,6 +2556,8 @@ components:
           format: double
           minimum: 0
           maximum: 100
+        feature:
+          type: string
         note:
           type: string
         wineVarietyIDs:
@@ -2445,3 +2810,221 @@ components:
       required:
         - email
         - otp
+    ScoreComponentResult:
+      type: object
+      description: Earned and maximum points for a single score component.
+      properties:
+        component:
+          type: string
+          enum:
+            - region
+            - variety
+            - vintage
+            - alcohol
+            - producer
+            - feature
+        earnedPoints:
+          type: integer
+          format: int32
+        maxPoints:
+          type: integer
+          format: int32
+      required:
+        - component
+        - earnedPoints
+        - maxPoints
+    QuestionScoreSummary:
+      type: object
+      description: Per-question score summary for a participant.
+      properties:
+        eventQuestionID:
+          type: string
+          format: uuid
+        earnedPoints:
+          type: integer
+          format: int32
+        maxPoints:
+          type: integer
+          format: int32
+        performance:
+          type: number
+          format: double
+      required:
+        - eventQuestionID
+        - earnedPoints
+        - maxPoints
+        - performance
+    EventParticipantScore:
+      type: object
+      description: Aggregate score for an event participant.
+      properties:
+        userID:
+          type: string
+          format: uuid
+        totalEarnedPoints:
+          type: integer
+          format: int32
+        totalMaxPoints:
+          type: integer
+          format: int32
+        questionScores:
+          type: array
+          items:
+            $ref: '#/components/schemas/QuestionScoreSummary'
+      required:
+        - userID
+        - totalEarnedPoints
+        - totalMaxPoints
+        - questionScores
+    EventLeaderboardEntry:
+      type: object
+      description: A ranked entry on an event score leaderboard.
+      properties:
+        rank:
+          type: integer
+          format: int32
+        userID:
+          type: string
+          format: uuid
+        totalEarnedPoints:
+          type: integer
+          format: int32
+        totalMaxPoints:
+          type: integer
+          format: int32
+      required:
+        - rank
+        - userID
+        - totalEarnedPoints
+        - totalMaxPoints
+    EventQuestionUserScore:
+      type: object
+      description: Per-user score and component breakdown for a question.
+      properties:
+        userID:
+          type: string
+          format: uuid
+        earnedPoints:
+          type: integer
+          format: int32
+        maxPoints:
+          type: integer
+          format: int32
+        performance:
+          type: number
+          format: double
+        components:
+          type: array
+          items:
+            $ref: '#/components/schemas/ScoreComponentResult'
+      required:
+        - userID
+        - earnedPoints
+        - maxPoints
+        - performance
+        - components
+    RatingLedgerEntry:
+      type: object
+      description: A rating change recorded after a question performance.
+      properties:
+        id:
+          type: string
+          format: uuid
+        eventQuestionID:
+          type: string
+          format: uuid
+        performance:
+          type: number
+          format: double
+        fieldAverage:
+          type: number
+          format: double
+        delta:
+          type: integer
+          format: int32
+        ratingAfter:
+          type: integer
+          format: int32
+        createdAt:
+          type: number
+          format: double
+      required:
+        - id
+        - eventQuestionID
+        - performance
+        - fieldAverage
+        - delta
+        - ratingAfter
+        - createdAt
+    UserRating:
+      type: object
+      description: The authenticated user's seasonal rating and recent ledger.
+      properties:
+        seasonID:
+          type: string
+          format: uuid
+        seasonName:
+          type: string
+        rating:
+          type: integer
+          format: int32
+        recentLedger:
+          type: array
+          items:
+            $ref: '#/components/schemas/RatingLedgerEntry'
+      required:
+        - seasonID
+        - seasonName
+        - rating
+        - recentLedger
+    RatingLeaderboardEntry:
+      type: object
+      description: A ranked entry on a seasonal rating leaderboard.
+      properties:
+        rank:
+          type: integer
+          format: int32
+        userID:
+          type: string
+          format: uuid
+        rating:
+          type: integer
+          format: int32
+      required:
+        - rank
+        - userID
+        - rating
+    CreateRatingSeasonRequest:
+      type: object
+      description: A request to create a rating season.
+      properties:
+        name:
+          type: string
+      required:
+        - name
+    RatingSeason:
+      type: object
+      description: A rating season window.
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        startsAt:
+          type: number
+          format: double
+        endsAt:
+          type:
+            - number
+            - 'null'
+          format: double
+        createdAt:
+          type: number
+          format: double
+      required:
+        - id
+        - name
+        - startsAt
+        - endsAt
+        - createdAt

--- a/public/index.html
+++ b/public/index.html
@@ -279,9 +279,16 @@
 
         <div class="grid-2">
           <div class="field">
-            <label for="event-answer-published-at">正解公開日時 (任意)</label>
-            <input id="event-answer-published-at" type="datetime-local">
+            <label for="event-responses-due-at">回答期限 *</label>
+            <input id="event-responses-due-at" type="datetime-local" required>
           </div>
+          <div class="field">
+            <label for="event-answer-published-at">正解公開日時 *</label>
+            <input id="event-answer-published-at" type="datetime-local" required>
+          </div>
+        </div>
+
+        <div class="grid-2">
           <div class="field">
             <label for="event-capacity">定員 (任意, 1以上)</label>
             <input id="event-capacity" type="number" min="1" step="1">


### PR DESCRIPTION
## Summary
- イベントに回答期限（`responsesDueAt`）を追加し、正解公開（`answersPublishedAt`）を必須化。回答提出は開催開始から回答期限まで。
- 配点をイベント単位から問題単位へ移し、産地階層・品種・年号・度数・生産者/特徴の採点エンジンを追加。
- 正解公開後に問題ごとの得点率と参加者平均からレーティングを変動させ、シーズン切替・リーダーボード API を追加。

## Test plan
- [ ] Atlas migration `20260712120000_scoring_and_rating` を適用できる
- [ ] イベント作成で `responsesDueAt` / `answersPublishedAt` 必須と順序バリデーションが効く
- [ ] 問題作成時に `regionScoreRules` / `scoreComponentRules` を保存・取得できる
- [ ] 回答期限前のみ回答提出でき、公開前のスコア API は参加者に 403、主催者はプレビュー可
- [ ] 公開後にスコア・イベントリーダーボードが返り、レーティング ledger が idempotent に記録される
- [ ] `swift test --filter ScoringTests` が通る


Made with [Cursor](https://cursor.com)